### PR TITLE
feat: impl bi-direction seek

### DIFF
--- a/storage/src/lsm_tree/iterator/mod.rs
+++ b/storage/src/lsm_tree/iterator/mod.rs
@@ -17,7 +17,8 @@ pub enum Seek<'s> {
     /// Seek to the last valid position in order if exists.
     Last,
     /// Seek to the position that the given key can be inserted into in order if exists.
-    Random(&'s [u8]),
+    RandomForward(&'s [u8]),
+    RandomBackward(&'s [u8]),
 }
 
 /// [`Iterator`] defines shared behaviours for all iterators.


### PR DESCRIPTION
Impl bi-direction seek. Fix reversing for `MergeIterator`.

The implementation of backward seek simply does a `prev_until_key`. For the *full key (user key | timestamp)* should not be duplicated, the cost is acceptable.

Ref: #1 #25 

Fix: #26 