### PR TITLE
feat: impl user key iterator

### DIFF
--- a/storage/src/lsm_tree/iterator/merge_iterator.rs
+++ b/storage/src/lsm_tree/iterator/merge_iterator.rs
@@ -206,131 +206,115 @@ mod tests {
 
     #[tokio::test]
     async fn test_seek_first() {
-        let mut mi = build_iterator_for_test();
-        mi.seek(Seek::First).await.unwrap();
-        assert!(mi.is_valid());
-        assert_eq!(&full_key(b"k01", 1)[..], mi.key());
-        assert_eq!(b"v01", mi.value());
+        let mut it = build_iterator_for_test();
+        it.seek(Seek::First).await.unwrap();
+        assert_eq!(&full_key(b"k01", 1)[..], it.key());
     }
 
     #[tokio::test]
     async fn test_seek_last() {
-        let mut mi = build_iterator_for_test();
-        mi.seek(Seek::Last).await.unwrap();
-        assert!(mi.is_valid());
-        assert_eq!(&full_key(b"k11", 11)[..], mi.key());
-        assert_eq!(b"v11", mi.value());
-    }
-
-    #[tokio::test]
-    async fn test_seek_random() {
-        let mut mi = build_iterator_for_test();
-        mi.seek(Seek::RandomForward(&full_key(b"k06", 6)[..]))
-            .await
-            .unwrap();
-        assert!(mi.is_valid());
-        assert_eq!(&full_key(b"k06", 6)[..], mi.key());
-        assert_eq!(b"v06", mi.value());
+        let mut it = build_iterator_for_test();
+        it.seek(Seek::Last).await.unwrap();
+        assert_eq!(&full_key(b"k11", 11)[..], it.key());
     }
 
     #[tokio::test]
     async fn test_seek_none_front() {
-        let mut mi = build_iterator_for_test();
-        mi.seek(Seek::RandomForward(&full_key(b"k00", 0)[..]))
+        let mut it = build_iterator_for_test();
+        it.seek(Seek::RandomForward(&full_key(b"k00", 0)[..]))
             .await
             .unwrap();
-        assert!(mi.is_valid());
-        assert_eq!(&full_key(b"k01", 1)[..], mi.key());
-        assert_eq!(b"v01", mi.value());
-    }
+        assert_eq!(&full_key(b"k01", 1)[..], it.key());
 
-    #[tokio::test]
-    async fn test_seek_none_middle() {
-        let mut mi = build_iterator_for_test();
-        mi.seek(Seek::RandomForward(&full_key(b"k04", 4)[..]))
+        let mut it = build_iterator_for_test();
+        it.seek(Seek::RandomBackward(&full_key(b"k00", 0)[..]))
             .await
             .unwrap();
-        assert!(mi.is_valid());
-        assert_eq!(&full_key(b"k05", 5)[..], mi.key());
-        assert_eq!(b"v05", mi.value());
+        assert!(!it.is_valid());
     }
 
     #[tokio::test]
     async fn test_seek_none_back() {
-        let mut mi = build_iterator_for_test();
-        mi.seek(Seek::RandomForward(&full_key(b"k12", 12)[..]))
+        let mut it = build_iterator_for_test();
+        it.seek(Seek::RandomForward(&full_key(b"k12", 12)[..]))
             .await
             .unwrap();
-        assert!(!mi.is_valid());
-    }
+        assert!(!it.is_valid());
 
-    #[tokio::test]
-    async fn test_forward_iterate() {
-        let mut mi = build_iterator_for_test();
-
-        mi.seek(Seek::First).await.unwrap();
-        for i in (1..=3).chain(5..=7).chain(9..=11) {
-            assert!(mi.is_valid());
-            assert_eq!(
-                &full_key(format!("k{:02}", i).as_bytes(), i as u64)[..],
-                mi.key()
-            );
-            assert_eq!(format!("v{:02}", i).as_bytes(), mi.value());
-            mi.next().await.unwrap();
-        }
-        assert!(!mi.is_valid())
-    }
-
-    #[tokio::test]
-    async fn test_backward_iterate() {
-        let mut mi = build_iterator_for_test();
-
-        mi.seek(Seek::Last).await.unwrap();
-        for i in (1..=3).chain(5..=7).chain(9..=11).rev() {
-            assert!(mi.is_valid());
-            assert_eq!(
-                &full_key(format!("k{:02}", i).as_bytes(), i as u64)[..],
-                mi.key()
-            );
-            assert_eq!(format!("v{:02}", i).as_bytes(), mi.value());
-            mi.prev().await.unwrap();
-        }
-        assert!(!mi.is_valid())
-    }
-
-    #[tokio::test]
-    async fn test_seek_forward_backward_iterate() {
-        let mut mi = build_iterator_for_test();
-
-        mi.seek(Seek::RandomForward(&full_key(b"k06", 6)[..]))
+        let mut it = build_iterator_for_test();
+        it.seek(Seek::RandomBackward(&full_key(b"k12", 12)[..]))
             .await
             .unwrap();
-        assert_eq!(&full_key(format!("k{:02}", 6).as_bytes(), 6)[..], mi.key());
-
-        mi.prev().await.unwrap();
-        assert_eq!(&full_key(format!("k{:02}", 5).as_bytes(), 5)[..], mi.key());
-
-        mi.prev().await.unwrap();
-        assert_eq!(&full_key(format!("k{:02}", 3).as_bytes(), 3)[..], mi.key());
-
-        mi.next().await.unwrap();
-        assert_eq!(&full_key(format!("k{:02}", 5).as_bytes(), 5)[..], mi.key());
-
-        mi.next().await.unwrap();
-        assert_eq!(&full_key(format!("k{:02}", 6).as_bytes(), 6)[..], mi.key());
+        assert_eq!(&full_key(b"k11", 11)[..], it.key());
     }
 
     #[tokio::test]
     async fn bi_direction_seek() {
-        let mut mi = build_iterator_for_test();
-        mi.seek(Seek::RandomForward(&full_key(b"k04", 4)[..]))
+        let mut it = build_iterator_for_test();
+        it.seek(Seek::RandomForward(&full_key(b"k04", 4)[..]))
             .await
             .unwrap();
-        assert_eq!(&full_key(format!("k{:02}", 5).as_bytes(), 5)[..], mi.key());
+        assert_eq!(&full_key(format!("k{:02}", 5).as_bytes(), 5)[..], it.key());
 
-        mi.seek(Seek::RandomBackward(&full_key(b"k04", 4)[..]))
+        it.seek(Seek::RandomBackward(&full_key(b"k04", 4)[..]))
             .await
             .unwrap();
-        assert_eq!(&full_key(format!("k{:02}", 3).as_bytes(), 3)[..], mi.key());
+        assert_eq!(&full_key(format!("k{:02}", 3).as_bytes(), 3)[..], it.key());
+    }
+
+    #[tokio::test]
+    async fn test_forward_iterate() {
+        let mut it = build_iterator_for_test();
+
+        it.seek(Seek::First).await.unwrap();
+        for i in (1..=3).chain(5..=7).chain(9..=11) {
+            assert!(it.is_valid());
+            assert_eq!(
+                &full_key(format!("k{:02}", i).as_bytes(), i as u64)[..],
+                it.key()
+            );
+            assert_eq!(format!("v{:02}", i).as_bytes(), it.value());
+            it.next().await.unwrap();
+        }
+        assert!(!it.is_valid())
+    }
+
+    #[tokio::test]
+    async fn test_backward_iterate() {
+        let mut it = build_iterator_for_test();
+
+        it.seek(Seek::Last).await.unwrap();
+        for i in (1..=3).chain(5..=7).chain(9..=11).rev() {
+            assert!(it.is_valid());
+            assert_eq!(
+                &full_key(format!("k{:02}", i).as_bytes(), i as u64)[..],
+                it.key()
+            );
+            assert_eq!(format!("v{:02}", i).as_bytes(), it.value());
+            it.prev().await.unwrap();
+        }
+        assert!(!it.is_valid())
+    }
+
+    #[tokio::test]
+    async fn test_seek_forward_backward_iterate() {
+        let mut it = build_iterator_for_test();
+
+        it.seek(Seek::RandomForward(&full_key(b"k06", 6)[..]))
+            .await
+            .unwrap();
+        assert_eq!(&full_key(format!("k{:02}", 6).as_bytes(), 6)[..], it.key());
+
+        it.prev().await.unwrap();
+        assert_eq!(&full_key(format!("k{:02}", 5).as_bytes(), 5)[..], it.key());
+
+        it.prev().await.unwrap();
+        assert_eq!(&full_key(format!("k{:02}", 3).as_bytes(), 3)[..], it.key());
+
+        it.next().await.unwrap();
+        assert_eq!(&full_key(format!("k{:02}", 5).as_bytes(), 5)[..], it.key());
+
+        it.next().await.unwrap();
+        assert_eq!(&full_key(format!("k{:02}", 6).as_bytes(), 6)[..], it.key());
     }
 }

--- a/storage/src/lsm_tree/iterator/mod.rs
+++ b/storage/src/lsm_tree/iterator/mod.rs
@@ -1,13 +1,17 @@
+// TODO: Refine the comments of this file.
+
 mod block_iterator;
 mod concat_iterator;
 mod merge_iterator;
 mod sstable_iterator;
+mod user_key_iterator;
 
 use async_trait::async_trait;
 pub use block_iterator::*;
 pub use concat_iterator::*;
 pub use merge_iterator::*;
 pub use sstable_iterator::*;
+pub use user_key_iterator::*;
 
 use crate::Result;
 
@@ -16,8 +20,9 @@ pub enum Seek<'s> {
     First,
     /// Seek to the last valid position in order if exists.
     Last,
-    /// Seek to the position that the given key can be inserted into in order if exists.
+    /// Seek forward for the first key euqals the given key or the frist key bigger than it.
     RandomForward(&'s [u8]),
+    /// Seek backward for the first key equals the given key or the first key smaller than it.
     RandomBackward(&'s [u8]),
 }
 

--- a/storage/src/lsm_tree/iterator/mod.rs
+++ b/storage/src/lsm_tree/iterator/mod.rs
@@ -1,5 +1,3 @@
-// TODO: Refine the comments of this file.
-
 mod block_iterator;
 mod concat_iterator;
 mod merge_iterator;
@@ -95,8 +93,7 @@ pub trait Iterator: Send + Sync {
     /// - This function should be straightforward and return immediately.
     fn is_valid(&self) -> bool;
 
-    /// Reset iterator and seek to the first position where the key >= provided key, or key <=
-    /// provided key if this is a reverse iterator.
+    /// Initialize or reset iterator with the given seek mode. For more details, refer to [`Seek`].
     ///
     /// Note:
     ///

--- a/storage/src/lsm_tree/iterator/user_key_iterator.rs
+++ b/storage/src/lsm_tree/iterator/user_key_iterator.rs
@@ -1,0 +1,325 @@
+use async_trait::async_trait;
+use bytes::Bytes;
+
+use super::{BoxedIterator, Iterator, Seek};
+use crate::{timestamp, user_key, Result};
+
+pub struct UserKeyIterator {
+    /// Inner full key iterator.
+    ///
+    /// Note: `iter` is always valid when [`UserKeyIterator`] is valid.
+    iter: BoxedIterator,
+    // TODO: Should replaced with a `Snapshot` handler with epoch inside to pin the sst?
+    /// Timestamp for snapshot read.
+    timestamp: u64,
+    /// Current user key.
+    key: Bytes,
+}
+
+impl UserKeyIterator {
+    pub fn new(iter: BoxedIterator, timestamp: u64) -> Self {
+        Self {
+            iter,
+            timestamp,
+            key: Bytes::default(),
+        }
+    }
+
+    /// Note: Ensure that the current state is valid.
+    async fn next_inner(&mut self) -> Result<()> {
+        loop {
+            if !self.iter.is_valid() {
+                return Ok(());
+            }
+            let user_key = user_key(self.iter.key());
+            let timestamp = timestamp(self.iter.key());
+            if self.timestamp >= timestamp && user_key != self.key {
+                self.key = Bytes::from(user_key.to_vec());
+                return Ok(());
+            }
+            // Call inner iter `next` later. It's useful to impl `Seel::First`.
+            self.iter.next().await?;
+        }
+    }
+
+    /// Note: Ensure that the current state is valid.
+    async fn prev_inner(&mut self) -> Result<()> {
+        loop {
+            if !self.iter.is_valid() {
+                return Ok(());
+            }
+            let user_key = user_key(self.iter.key());
+            let timestamp = timestamp(self.iter.key());
+            if self.timestamp >= timestamp && user_key != self.key {
+                self.key = Bytes::from(user_key.to_vec());
+                return self.prev_until_key().await;
+            }
+            // Call inner iter `prev` later. It's useful to impl `Seel::Last`.
+            self.iter.prev().await?;
+        }
+    }
+
+    /// Move backward until reach the first visiable key of the current user key.
+    ///
+    /// Note: Ensure that the current state is valid. And the current user key must have at least
+    /// one visiable version.
+    async fn prev_until_key(&mut self) -> Result<()> {
+        loop {
+            self.iter.prev().await?;
+            if !self.iter.is_valid() {
+                return self.iter.seek(Seek::First).await;
+            }
+            let user_key = user_key(self.iter.key());
+            let timestamp = timestamp(self.iter.key());
+            if self.key != user_key || self.timestamp < timestamp {
+                return self.iter.next().await;
+            }
+        }
+    }
+}
+
+#[async_trait]
+impl Iterator for UserKeyIterator {
+    async fn next(&mut self) -> Result<()> {
+        assert!(self.is_valid());
+        self.next_inner().await
+    }
+
+    async fn prev(&mut self) -> Result<()> {
+        assert!(self.is_valid());
+        self.prev_inner().await
+    }
+
+    fn key(&self) -> &[u8] {
+        assert!(self.is_valid());
+        &self.key
+    }
+
+    fn value(&self) -> &[u8] {
+        assert!(self.is_valid());
+        self.iter.value()
+    }
+
+    fn is_valid(&self) -> bool {
+        self.iter.is_valid()
+    }
+
+    async fn seek<'s>(&mut self, seek: Seek<'s>) -> Result<()> {
+        match seek {
+            Seek::First => {
+                self.key = Bytes::default();
+                self.iter.seek(Seek::First).await?;
+                self.next_inner().await
+            }
+            Seek::Last => {
+                self.key = Bytes::default();
+                self.iter.seek(Seek::Last).await?;
+                self.prev_inner().await
+            }
+            Seek::RandomForward(key) => {
+                self.key = Bytes::default();
+                self.iter.seek(Seek::RandomForward(key)).await?;
+                self.next_inner().await
+            }
+            Seek::RandomBackward(key) => {
+                self.key = Bytes::default();
+                self.iter.seek(Seek::RandomBackward(key)).await?;
+                self.prev_inner().await
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use super::*;
+    use crate::{full_key, Block, BlockBuilder, BlockBuilderOptions, BlockIterator};
+
+    fn build_iterator_for_test(timestamp: u64) -> UserKeyIterator {
+        let block = build_block_for_test();
+        let bi = BlockIterator::new(block);
+        UserKeyIterator::new(Box::new(bi), timestamp)
+    }
+
+    fn build_block_for_test() -> Arc<Block> {
+        let options = BlockBuilderOptions::default();
+        let mut builder = BlockBuilder::new(options);
+        for (k, ts) in [
+            (3, vec![3, 2]),
+            (5, vec![5, 4, 3, 2, 1]),
+            (7, vec![3, 2]),
+            (9, vec![5, 4, 3, 2, 1]),
+            (11, vec![3, 2]),
+        ]
+        .into_iter()
+        {
+            for t in ts {
+                builder.add(
+                    &full_key(format!("k{:02}", k).as_bytes(), t),
+                    &Bytes::from(format!("v{:02}-{:02}", k, t)),
+                );
+            }
+        }
+        let buf = builder.build();
+        Arc::new(Block::decode(buf).unwrap())
+    }
+
+    #[tokio::test]
+    async fn test_seek_first() {
+        let mut it = build_iterator_for_test(u64::MAX);
+        it.seek(Seek::First).await.unwrap();
+        assert_eq!(b"v03-03", it.value());
+
+        let mut it = build_iterator_for_test(2);
+        it.seek(Seek::First).await.unwrap();
+        assert_eq!(b"v03-02", it.value());
+
+        let mut it = build_iterator_for_test(1);
+        it.seek(Seek::First).await.unwrap();
+        assert_eq!(b"v05-01", it.value());
+
+        let mut it = build_iterator_for_test(0);
+        it.seek(Seek::First).await.unwrap();
+        assert!(!it.is_valid());
+    }
+
+    #[tokio::test]
+    async fn test_seek_last() {
+        let mut it = build_iterator_for_test(u64::MAX);
+        it.seek(Seek::Last).await.unwrap();
+        assert_eq!(b"v11-03", it.value());
+
+        let mut it = build_iterator_for_test(2);
+        it.seek(Seek::Last).await.unwrap();
+        assert_eq!(b"v11-02", it.value());
+
+        let mut it = build_iterator_for_test(1);
+        it.seek(Seek::Last).await.unwrap();
+        assert_eq!(b"v09-01", it.value());
+
+        let mut it = build_iterator_for_test(0);
+        it.seek(Seek::Last).await.unwrap();
+        assert!(!it.is_valid());
+    }
+
+    #[tokio::test]
+    async fn test_bi_direction_seek() {
+        // Forward.
+
+        let mut it = build_iterator_for_test(u64::MAX);
+        it.seek(Seek::RandomForward(b"k06")).await.unwrap();
+        assert_eq!(b"v07-03", it.value());
+
+        let mut it = build_iterator_for_test(2);
+        it.seek(Seek::RandomForward(b"k06")).await.unwrap();
+        assert_eq!(b"v07-02", it.value());
+
+        let mut it = build_iterator_for_test(1);
+        it.seek(Seek::RandomForward(b"k06")).await.unwrap();
+        assert_eq!(b"v09-01", it.value());
+
+        let mut it = build_iterator_for_test(0);
+        it.seek(Seek::RandomForward(b"k06")).await.unwrap();
+        assert!(!it.is_valid());
+
+        // Backward.
+
+        let mut it = build_iterator_for_test(u64::MAX);
+        it.seek(Seek::RandomBackward(b"k08")).await.unwrap();
+        assert_eq!(b"v07-03", it.value());
+
+        let mut it = build_iterator_for_test(2);
+        it.seek(Seek::RandomBackward(b"k08")).await.unwrap();
+        assert_eq!(b"v07-02", it.value());
+
+        let mut it = build_iterator_for_test(1);
+        it.seek(Seek::RandomBackward(b"k08")).await.unwrap();
+        assert_eq!(b"v05-01", it.value());
+
+        let mut it = build_iterator_for_test(0);
+        it.seek(Seek::RandomBackward(b"k08")).await.unwrap();
+        assert!(!it.is_valid());
+    }
+
+    #[tokio::test]
+    async fn test_seek_none_front() {
+        let mut it = build_iterator_for_test(u64::MAX);
+        it.seek(Seek::RandomForward(b"k01")).await.unwrap();
+        assert_eq!(b"v03-03", it.value());
+
+        let mut it = build_iterator_for_test(u64::MAX);
+        it.seek(Seek::RandomBackward(b"k01")).await.unwrap();
+        assert!(!it.is_valid());
+    }
+
+    #[tokio::test]
+    async fn test_seek_none_back() {
+        let mut it = build_iterator_for_test(u64::MAX);
+        it.seek(Seek::RandomForward(b"k12")).await.unwrap();
+        assert!(!it.is_valid());
+
+        let mut it = build_iterator_for_test(u64::MAX);
+        it.seek(Seek::RandomBackward(b"k12")).await.unwrap();
+        assert_eq!(b"v11-03", it.value());
+    }
+
+    #[tokio::test]
+    async fn test_forward_iterate() {
+        let mut it = build_iterator_for_test(2);
+        it.seek(Seek::First).await.unwrap();
+        assert_eq!(b"v03-02", it.value());
+
+        it.next().await.unwrap();
+        assert_eq!(b"v05-02", it.value());
+
+        it.next().await.unwrap();
+        assert_eq!(b"v07-02", it.value());
+
+        it.next().await.unwrap();
+        assert_eq!(b"v09-02", it.value());
+
+        it.next().await.unwrap();
+        assert_eq!(b"v11-02", it.value());
+
+        it.next().await.unwrap();
+        assert!(!it.is_valid());
+    }
+
+    #[tokio::test]
+    async fn test_backward_iterate() {
+        let mut it = build_iterator_for_test(2);
+        it.seek(Seek::Last).await.unwrap();
+        assert_eq!(b"v11-02", it.value());
+
+        it.prev().await.unwrap();
+        assert_eq!(b"v09-02", it.value());
+
+        it.prev().await.unwrap();
+        assert_eq!(b"v07-02", it.value());
+
+        it.prev().await.unwrap();
+        assert_eq!(b"v05-02", it.value());
+
+        it.prev().await.unwrap();
+        assert_eq!(b"v03-02", it.value());
+
+        it.prev().await.unwrap();
+        assert!(!it.is_valid());
+    }
+
+    #[tokio::test]
+    async fn test_seek_forward_backward_iterate() {
+        let mut it = build_iterator_for_test(2);
+
+        it.seek(Seek::RandomForward(b"k06")).await.unwrap();
+        assert_eq!(b"v07-02", it.value());
+
+        it.prev().await.unwrap();
+        assert_eq!(b"v05-02", it.value());
+
+        it.next().await.unwrap();
+        assert_eq!(b"v07-02", it.value());
+    }
+}

--- a/storage/src/lsm_tree/mod.rs
+++ b/storage/src/lsm_tree/mod.rs
@@ -1,3 +1,5 @@
+// TODO: Restrict pub use. Export only necessary components.
+
 mod iterator;
 pub use iterator::*;
 mod components;


### PR DESCRIPTION
As titled.

- Implement `UserKeyIterator`.
- Fix "backward seek for a key that larger than all keys" for all iterators.
- Refine iterator tests.

Ref: #1 #25 #26 