### PR TITLE
feat: expose timestamp for interfaces of lsm-tree

### DIFF
--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -2,8 +2,41 @@
 #![feature(assert_matches)]
 
 mod error;
-pub use error::*;
 mod lsm_tree;
-pub use lsm_tree::*;
 mod object_store;
+
+use async_trait::async_trait;
+use bytes::Bytes;
+pub use error::*;
+pub use lsm_tree::*;
 pub use object_store::*;
+
+#[async_trait]
+pub trait LsmTree: Send + Sync {
+    /// Put a new `key` `value` pair into LSM-Tree with given `timestamp`.
+    ///
+    /// # Safety
+    ///
+    /// The interface exposes `timestamp` to user for the compatibility with upper system. It's
+    /// caller's responsibility to ensure that the new timestamp is higher than the old one on the
+    /// same key. Otherwise there will be consistency problems.
+    async fn put(&self, key: &Bytes, value: &Bytes, timestamp: u64) -> Result<()>;
+
+    /// Delete a the given `key` in LSM-Tree by tombstone with given `timestamp`.
+    ///
+    /// # Safety
+    ///
+    /// The interface exposes `timestamp` to user for the compatibility with upper system. It's
+    /// caller's responsibility to ensure that the new timestamp is higher than the old one on the
+    /// same key. Otherwise there will be consistency problems.
+    async fn delete(&self, key: &Bytes, timestamp: u64) -> Result<()>;
+
+    /// Get the value of the given `key` in LSM-Tree with given `timestamp`.
+    ///
+    /// # Safety
+    ///
+    /// The interface exposes `timestamp` to user for the compatibility with upper system. It's
+    /// caller's responsibility to ensure that the new timestamp is higher than the old one on the
+    /// same key. Otherwise there will be consistency problems.
+    async fn get(&self, key: &Bytes, timestamp: u64) -> Result<Option<Bytes>>;
+}

--- a/storage/src/lsm_tree/iterator/memtable_iterator.rs
+++ b/storage/src/lsm_tree/iterator/memtable_iterator.rs
@@ -175,12 +175,12 @@ mod tests {
             for t in ts {
                 if t >= 0 {
                     memtable.put(
-                        format!("k{:02}", k).as_bytes(),
+                        &Bytes::from(format!("k{:02}", k)),
                         Some(&Bytes::from(format!("v{:02}-{:02}", k, t))),
                         t as u64,
                     );
                 } else {
-                    memtable.put(format!("k{:02}", k).as_bytes(), None, -t as u64);
+                    memtable.put(&Bytes::from(format!("k{:02}", k)), None, -t as u64);
                 }
             }
         }

--- a/storage/src/lsm_tree/s3_lsm_tree.rs
+++ b/storage/src/lsm_tree/s3_lsm_tree.rs
@@ -1,18 +1,20 @@
 use std::cell::RefCell;
 use std::collections::VecDeque;
 use std::marker::PhantomData;
-use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 
+use async_trait::async_trait;
 use bytes::Bytes;
 use bytesize::ByteSize;
 use parking_lot::RwLock;
 
 use crate::components::{BlockCache, Memtable, SstableStore, SstableStoreOptions, SstableStoreRef};
-use crate::iterator::{Iterator, Seek, SstableIterator, UserKeyIterator};
-use crate::manifest::{LevelOptions, VersionManager, VersionManagerOptions};
-use crate::utils::SKIPLIST_NODE_TOWER_MAX_HEIGHT;
-use crate::{ObjectStoreRef, Result};
+use crate::iterator::{Iterator, MergeIterator, Seek, SstableIterator, UserKeyIterator};
+use crate::manifest::{
+    LevelCompactionStrategy, LevelOptions, VersionManager, VersionManagerOptions,
+};
+use crate::utils::{value, SKIPLIST_NODE_TOWER_MAX_HEIGHT};
+use crate::{LsmTree, ObjectStoreRef, Result};
 
 #[derive(Clone)]
 pub struct S3LsmTreeOptions {
@@ -30,21 +32,20 @@ pub struct S3LsmTreeOptions {
     pub lsm_tree_level_options: Vec<LevelOptions>,
 }
 
-pub struct S3LsmTree {
+pub struct S3LsmTreeCore {
     /// Options.
     options: S3LsmTreeOptions,
     /// Current mutable memtable.
     memtable: RefCell<Memtable>,
     /// Immutable memtabls, waiting to be uploaded to S3.
     immutable_memtables: RefCell<VecDeque<Memtable>>,
-    version_manager: RwLock<VersionManager>,
+    version_manager: tokio::sync::RwLock<VersionManager>,
     sstable_store: SstableStoreRef,
-    /// TODO: Get from TSO.
-    timestamp: AtomicU64,
+    /// Use a external lock to tighten the critical section.
     rwlock: RwLock<PhantomData<Memtable>>,
 }
 
-impl S3LsmTree {
+impl S3LsmTreeCore {
     pub fn new(options: S3LsmTreeOptions) -> Self {
         let sstable_store_options = SstableStoreOptions {
             path: options.path.clone(),
@@ -67,17 +68,97 @@ impl S3LsmTree {
             options,
             memtable,
             immutable_memtables,
-            version_manager: RwLock::new(version_manager),
+            version_manager: tokio::sync::RwLock::new(version_manager),
             sstable_store,
-            timestamp: AtomicU64::new(0),
             rwlock: RwLock::new(PhantomData),
         }
     }
 
-    pub async fn put(&self, key: &[u8], value: Option<&[u8]>) -> Result<()> {
-        // TODO: Increase timestamp!
-        // TODO: TODO: Get / Set timestamp from TSO.
+    async fn put(&self, key: &Bytes, value: &Bytes, timestamp: u64) -> Result<()> {
+        self.write(key, Some(value), timestamp).await
+    }
 
+    async fn delete(&self, key: &Bytes, timestamp: u64) -> Result<()> {
+        self.write(key, None, timestamp).await
+    }
+
+    async fn get(&self, key: &Bytes, timestamp: u64) -> Result<Option<Bytes>> {
+        // Prevent current memtable and immutable memtable vec being modified.
+        let memtables = {
+            let guard = self.rwlock.read();
+            let imms = self.immutable_memtables.borrow();
+            let mut memtables = Vec::with_capacity(imms.len() + 1);
+            memtables.push(self.memtable.borrow().clone());
+            memtables.extend(imms.clone().drain(..));
+            drop(guard);
+            memtables
+        };
+
+        // Seek from memtables.
+        for memtable in memtables.iter() {
+            if let Some(raw) = memtable.get_raw(key, timestamp) {
+                return Ok(value(&raw).map(Bytes::copy_from_slice));
+            }
+        }
+
+        // Pick overlap ssts.
+        let levels = {
+            let version_manager_guard = self.version_manager.read().await;
+            let levels = version_manager_guard
+                .pick_overlap_ssts_by_key(0..version_manager_guard.levels(), key, timestamp)
+                .await
+                .unwrap();
+            drop(version_manager_guard);
+            levels
+        };
+
+        // Seek from ssts.
+        for (level_idx, level) in levels.into_iter().enumerate() {
+            if level.is_empty() {
+                continue;
+            }
+            let compaction_strategy = self
+                .version_manager
+                .read()
+                .await
+                .level_compaction_strategy(level_idx as u64)?;
+
+            let mut iter = match compaction_strategy {
+                LevelCompactionStrategy::Overlap => {
+                    let mut iters: Vec<Box<dyn Iterator>> = Vec::with_capacity(level.len());
+                    for sst_id in level {
+                        let sst = self.sstable_store.sstable(sst_id).await?;
+                        let iter = Box::new(SstableIterator::new(
+                            self.sstable_store.clone(),
+                            sst,
+                            crate::components::CachePolicy::Fill,
+                        ));
+                        iters.push(iter);
+                    }
+                    UserKeyIterator::new(Box::new(MergeIterator::new(iters)), timestamp)
+                }
+                LevelCompactionStrategy::NonOverlap => {
+                    assert_eq!(level.len(), 1);
+                    let sst = self.sstable_store.sstable(level[0]).await?;
+                    UserKeyIterator::new(
+                        Box::new(SstableIterator::new(
+                            self.sstable_store.clone(),
+                            sst,
+                            crate::components::CachePolicy::Fill,
+                        )),
+                        timestamp,
+                    )
+                }
+            };
+            iter.seek(Seek::RandomForward(key)).await?;
+            if iter.is_valid() && iter.key() == key {
+                return Ok(Some(Bytes::from(iter.value().to_vec())));
+            }
+        }
+        Ok(None)
+    }
+
+    async fn write(&self, key: &Bytes, value: Option<&Bytes>, timestamp: u64) -> Result<()> {
         // = key len + value len
         // + skiplist node height (8B) + skiplist node tower (4 * MAX)
         // + reserved (8B)
@@ -94,6 +175,7 @@ impl S3LsmTree {
         // Rotate active memtable within lock guard.
         if self.memtable.borrow().mem_remain() < approximate_size {
             let guard = self.rwlock.write();
+            println!("rotate!");
             let imm = self.memtable.borrow().clone();
             *self.memtable.borrow_mut() =
                 Memtable::new(self.options.meta_cache_capacity.0 as usize);
@@ -101,76 +183,34 @@ impl S3LsmTree {
             drop(guard);
         }
 
-        let ts = self.timestamp.fetch_add(1, Ordering::SeqCst) + 1;
-        self.memtable.borrow_mut().put(key, value, ts);
+        self.memtable.borrow_mut().put(key, value, timestamp);
         Ok(())
-    }
-
-    pub async fn delete(&self, key: &[u8]) -> Result<()> {
-        self.put(key, None).await
-    }
-
-    pub async fn get(&self, key: &[u8]) -> Result<Option<Bytes>> {
-        // TODO: Pin timestamp!
-        // TODO: TODO: Get / Set timestamp from TSO.
-
-        // Prevent current memtable and immutable memtable vec being modified.
-        let memtables = {
-            let guard = self.rwlock.read();
-            let imms = self.immutable_memtables.borrow();
-            let mut memtables = Vec::with_capacity(imms.len() + 1);
-            memtables.push(self.memtable.borrow().clone());
-            memtables.extend(imms.clone().drain(..));
-            drop(guard);
-            memtables
-        };
-
-        let ts = self.timestamp.load(Ordering::SeqCst);
-
-        // Seek from memtables.
-        for memtable in memtables.iter() {
-            if let Some(value) = memtable.get(key, ts) {
-                return Ok(Some(Bytes::from(value.to_vec())));
-            }
-        }
-
-        // Pick overlap ssts.
-        let levels = {
-            let version_manager_guard = self.version_manager.read();
-            let levels = version_manager_guard
-                .pick_overlap_ssts_by_key(0..version_manager_guard.levels(), key, ts)
-                .await
-                .unwrap();
-            drop(version_manager_guard);
-            levels
-        };
-
-        // Seek from ssts.
-        for level in levels {
-            for sst_ids in level {
-                let sst = self.sstable_store.sstable(sst_ids).await?;
-                let mut iter = UserKeyIterator::new(
-                    Box::new(SstableIterator::new(
-                        self.sstable_store.clone(),
-                        sst,
-                        crate::components::CachePolicy::Fill,
-                    )),
-                    ts,
-                );
-                iter.seek(Seek::RandomForward(key)).await?;
-                if iter.is_valid() && iter.key() == key {
-                    return Ok(Some(Bytes::from(iter.value().to_vec())));
-                }
-            }
-        }
-        Ok(None)
     }
 }
 
-pub type S3LsmTreeRef = Arc<S3LsmTree>;
+// unsafe impl Send for S3LsmTreeCore {}
+unsafe impl Sync for S3LsmTreeCore {}
 
-unsafe impl Send for S3LsmTree {}
-unsafe impl Sync for S3LsmTree {}
+pub struct S3LsmTree {
+    inner: Arc<S3LsmTreeCore>,
+}
+
+#[async_trait]
+impl LsmTree for S3LsmTree {
+    async fn put(&self, key: &Bytes, value: &Bytes, timestamp: u64) -> Result<()> {
+        self.inner.put(key, value, timestamp).await
+    }
+
+    async fn delete(&self, key: &Bytes, timestamp: u64) -> Result<()> {
+        self.inner.delete(key, timestamp).await
+    }
+
+    async fn get(&self, key: &Bytes, timestamp: u64) -> Result<Option<Bytes>> {
+        self.inner.get(key, timestamp).await
+    }
+}
+
+impl S3LsmTree {}
 
 #[cfg(test)]
 mod tests {
@@ -189,8 +229,8 @@ mod tests {
 
     #[test]
     fn ensure_send_sync() {
-        is_send_sync::<S3LsmTree>();
-        is_send_sync::<S3LsmTree>();
+        is_send_sync::<S3LsmTreeCore>();
+        is_send_sync::<S3LsmTreeCore>();
     }
 
     #[tokio::test]
@@ -203,37 +243,23 @@ mod tests {
                 async move {
                     let mut rng = thread_rng();
                     tokio::time::sleep(Duration::from_millis(rng.gen_range(0..500))).await;
-                    lsmtree_clone
-                        .put(
-                            format!("k{:08}", i).as_bytes(),
-                            Some(format!("v{:08}-1", i).as_bytes()),
-                        )
-                        .await
-                        .unwrap();
+                    lsmtree_clone.put(&key(i), &value(i), i * 4).await.unwrap();
+                    println!("put k{:08}", i);
                     assert_eq!(
-                        lsmtree_clone
-                            .get(format!("k{:08}", i).as_bytes())
-                            .await
-                            .unwrap(),
-                        Some(Bytes::from(format!("v{:08}-1", i))),
+                        lsmtree_clone.get(&key(i), i * 4).await.unwrap(),
+                        Some(value(i))
                     );
+                    lsmtree_clone.delete(&key(i), i * 4 + 1).await.unwrap();
+                    println!("delete k{:08}", i);
+                    assert_eq!(lsmtree_clone.get(&key(i), i * 4 + 1).await.unwrap(), None);
                     lsmtree_clone
-                        .delete(format!("k{:08}", i).as_bytes())
+                        .put(&key(i), &value(i), i * 4 + 2)
                         .await
                         .unwrap();
-                    lsmtree_clone
-                        .put(
-                            format!("k{:08}", i).as_bytes(),
-                            Some(format!("v{:08}-2", i).as_bytes()),
-                        )
-                        .await
-                        .unwrap();
+                    println!("put k{:08}", i);
                     assert_eq!(
-                        lsmtree_clone
-                            .get(format!("k{:08}", i).as_bytes())
-                            .await
-                            .unwrap(),
-                        Some(Bytes::from(format!("v{:08}-2", i))),
+                        lsmtree_clone.get(&key(i), i * 4 + 2).await.unwrap(),
+                        Some(value(i))
                     );
                 }
             })
@@ -241,7 +267,7 @@ mod tests {
         future::join_all(futures).await;
     }
 
-    fn default_s3_lsm_tree_options_for_test() -> S3LsmTree {
+    fn default_s3_lsm_tree_options_for_test() -> S3LsmTreeCore {
         let object_store = Arc::new(MemObjectStore::default());
         let options = S3LsmTreeOptions {
             path: "test".to_string(),
@@ -280,6 +306,14 @@ mod tests {
                 },
             ],
         };
-        S3LsmTree::new(options)
+        S3LsmTreeCore::new(options)
+    }
+
+    fn key(i: u64) -> Bytes {
+        Bytes::from(format!("k{:08}", i))
+    }
+
+    fn value(i: u64) -> Bytes {
+        Bytes::from(format!("v{:08}", i))
     }
 }


### PR DESCRIPTION
Expose the timestamp for interfaces of LSMTree.

```plain
Safety: 

The interface exposes `timestamp` to user for the compatibility with upper system. It's
caller's responsibility to ensure that the new timestamp is higher than the old one on the
same key. Otherwise there will be consistency problems.
```

Not fix: #53 .
Ref: #44 .