### PR TITLE
fix: full key compare

### DIFF
--- a/common/src/config.rs
+++ b/common/src/config.rs
@@ -18,6 +18,8 @@ pub struct LevelOptions {
 
 #[derive(Deserialize, Clone, Default, Debug)]
 pub struct LsmTreeConfig {
+    pub l1_capacity: String,
+    pub level_multiplier: usize,
     pub trigger_l0_compaction_ssts: usize,
     pub trigger_l0_compaction_interval: String,
     pub trigger_compaction_interval: String,

--- a/storage/src/lsm_tree/components/memtable.rs
+++ b/storage/src/lsm_tree/components/memtable.rs
@@ -1,30 +1,18 @@
 use bytes::Bytes;
 
-use crate::lsm_tree::utils::{full_key, raw_value, value, IterRef, KeyComparator, Skiplist};
-
-#[derive(Clone)]
-pub struct Comparator;
-
-impl KeyComparator for Comparator {
-    fn compare_key(&self, lhs: &[u8], rhs: &[u8]) -> std::cmp::Ordering {
-        lhs.cmp(rhs)
-    }
-
-    fn same_key(&self, lhs: &[u8], rhs: &[u8]) -> bool {
-        lhs.len() == rhs.len() && lhs[..lhs.len() - 8] == rhs[..rhs.len() - 8]
-    }
-}
+use crate::lsm_tree::utils::{full_key, raw_value, value, IterRef, Skiplist};
+use crate::utils::FullKeyComparator;
 
 #[derive(Clone)]
 pub struct Memtable {
-    inner: Skiplist<Comparator>,
+    inner: Skiplist<FullKeyComparator>,
     capacity: usize,
 }
 
 impl Memtable {
     pub fn new(capacity: usize) -> Self {
         Self {
-            inner: Skiplist::with_capacity(Comparator, capacity as u32),
+            inner: Skiplist::with_capacity(FullKeyComparator, capacity as u32),
             capacity,
         }
     }
@@ -52,7 +40,9 @@ impl Memtable {
         self.inner.mem_size() as usize
     }
 
-    pub(in crate::lsm_tree) fn iter(&self) -> IterRef<Skiplist<Comparator>, Comparator> {
+    pub(in crate::lsm_tree) fn iter(
+        &self,
+    ) -> IterRef<Skiplist<FullKeyComparator>, FullKeyComparator> {
         self.inner.iter()
     }
 
@@ -60,7 +50,7 @@ impl Memtable {
         self.inner.is_empty()
     }
 
-    pub fn unwrap(self) -> Skiplist<Comparator> {
+    pub fn unwrap(self) -> Skiplist<FullKeyComparator> {
         self.inner
     }
 }

--- a/storage/src/lsm_tree/iterator/block_iterator.rs
+++ b/storage/src/lsm_tree/iterator/block_iterator.rs
@@ -6,6 +6,7 @@ use bytes::{Bytes, BytesMut};
 
 use super::{Iterator, Seek};
 use crate::components::{Block, KeyPrefix};
+use crate::utils::compare_full_key;
 use crate::Result;
 
 /// [`BlockIterator`] is used to read kv pairs in a block.
@@ -70,14 +71,14 @@ impl BlockIterator {
 
     /// Move forward until reach the first that equals or larger than the given `key`.
     fn next_until_key(&mut self, key: &[u8]) {
-        while self.is_valid() && (&self.key[..]).cmp(key) == Ordering::Less {
+        while self.is_valid() && compare_full_key(&self.key[..], key) == Ordering::Less {
             self.next_inner();
         }
     }
 
     /// Move backward until reach the first key that equals or smaller than the given `key`.
     fn prev_until_key(&mut self, key: &[u8]) {
-        while self.is_valid() && (&self.key[..]).cmp(key) == Ordering::Greater {
+        while self.is_valid() && compare_full_key(&self.key[..], key) == Ordering::Greater {
             self.prev_inner();
         }
     }
@@ -116,7 +117,7 @@ impl BlockIterator {
         self.block.search_restart_point_by(|probe| {
             let prefix = self.decode_prefix_at(*probe as usize);
             let probe_key = self.block.slice(prefix.diff_key_range());
-            (&probe_key[..]).cmp(key)
+            compare_full_key(&probe_key[..], key)
         })
     }
 

--- a/storage/src/lsm_tree/iterator/concat_iterator.rs
+++ b/storage/src/lsm_tree/iterator/concat_iterator.rs
@@ -3,6 +3,7 @@ use std::cmp::Ordering;
 use async_trait::async_trait;
 
 use super::{BoxedIterator, Iterator, Seek};
+use crate::utils::compare_full_key;
 use crate::Result;
 
 pub struct ConcatIterator {
@@ -70,7 +71,7 @@ impl ConcatIterator {
 
     /// Move backward until reach the first key that equals or smaller than the given `key`.
     async fn prev_until_key(&mut self, key: &[u8]) -> Result<()> {
-        while self.is_valid() && self.key().cmp(key) == Ordering::Greater {
+        while self.is_valid() && compare_full_key(self.key(), key) == Ordering::Greater {
             self.prev_inner().await?;
         }
         Ok(())
@@ -108,7 +109,7 @@ impl ConcatIterator {
             let iter = &mut self.iters[mid];
             iter.seek(Seek::RandomForward(key)).await?;
             let cmp = if iter.is_valid() {
-                iter.key().cmp(key)
+                compare_full_key(iter.key(), key)
             } else {
                 Less
             };

--- a/storage/src/lsm_tree/iterator/memtable_iterator.rs
+++ b/storage/src/lsm_tree/iterator/memtable_iterator.rs
@@ -2,14 +2,16 @@ use async_trait::async_trait;
 use bytes::Bytes;
 
 use super::{Iterator, Seek};
-use crate::components::{Comparator, Memtable};
+use crate::components::Memtable;
 use crate::lsm_tree::utils::{full_key, timestamp, user_key, value, IterRef, Skiplist};
+use crate::utils::FullKeyComparator;
 use crate::Result;
+
 pub struct MemtableIterator {
     /// Inner skiiplist iterator.
     ///
     /// Note: `iter` is always valid when [`MemtableIterator`] is valid.
-    iter: IterRef<Skiplist<Comparator>, Comparator>,
+    iter: IterRef<Skiplist<FullKeyComparator>, FullKeyComparator>,
     // TODO: Should replaced with a `Snapshot` handler with epoch inside to pin the sst?
     /// Timestamp for snapshot read.
     timestamp: u64,

--- a/storage/src/lsm_tree/iterator/mod.rs
+++ b/storage/src/lsm_tree/iterator/mod.rs
@@ -13,6 +13,7 @@ pub use merge_iterator::*;
 pub use sstable_iterator::*;
 pub use user_key_iterator::*;
 
+use crate::utils::compare_full_key;
 use crate::Result;
 
 pub enum Seek<'s> {
@@ -126,6 +127,7 @@ impl PartialOrd for BoxedIterator {
 
 impl Ord for BoxedIterator {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        self.key().cmp(other.key())
+        // Should not be used on `UserKeyIterator`
+        compare_full_key(self.key(), other.key())
     }
 }

--- a/tests/etc/lsm_tree.toml
+++ b/tests/etc/lsm_tree.toml
@@ -1,4 +1,7 @@
 [lsm_tree]
+l1_capacity = "1 MiB"
+level_multiplier = 10
+
 trigger_l0_compaction_ssts = 4
 trigger_l0_compaction_interval = "500 ms"
 trigger_compaction_interval = "5 s"


### PR DESCRIPTION
*user key* and *timestamp* are supposed to be compared separately.

Consider this example:

```
       user key | timestamp (desc)
k1 :         k1 | 999
k2:         k11 | 000
```

If *user key* and *timestamp* are **NOT** compared separately, k2 would be **less than** k1.