### PR TITLE
feat: reduce ssts involved in compaction

### DIFF
--- a/exhauster/src/compaction_filter.rs
+++ b/exhauster/src/compaction_filter.rs
@@ -22,7 +22,6 @@ impl DefaultCompactionFilter {
 }
 
 impl CompactionFilter for DefaultCompactionFilter {
-    #[allow(clippy::collapsible_else_if)]
     fn filter(&mut self, key: &[u8], _value: Option<&[u8]>, timestamp: u64) -> bool {
         let mut retain = true;
         // TODO: Handle `remove_tombstone`.

--- a/storage/src/lsm_tree/manifest/version.rs
+++ b/storage/src/lsm_tree/manifest/version.rs
@@ -166,7 +166,7 @@ impl VersionManagerCore {
         self.diffs.push_back(diff);
         if !sync {
             trace!("updated levels: {:?}", self.levels);
-            trace!("updated levels: {:#?}", self.levels_data_size);
+            trace!("updated levels size: {:#?}", self.levels_data_size);
         }
         Ok(())
     }


### PR DESCRIPTION
As titled.

Fix:
- Multi versions of one key should not be split into multi ssts.

Ref:
#30 .