### PR TITLE
feat: raft log store (part 4)

### DIFF
--- a/storage/src/raft_log_store/store.rs
+++ b/storage/src/raft_log_store/store.rs
@@ -5,7 +5,7 @@ use itertools::Itertools;
 use tracing::trace;
 
 use super::block_cache::BlockCache;
-use super::entry::{Entry, RaftLogBatch};
+use super::entry::{Compact, Entry, Kv, RaftLogBatch};
 use super::log::{Log, LogOptions, LogRef};
 use super::mem::{EntryIndex, MemStates};
 use crate::error::Result;
@@ -23,6 +23,13 @@ struct RaftLogStoreCore {
     block_cache: BlockCache,
 }
 
+/// [`RaftLogStore`] is designed for storing raft log entries and some small kv pairs from multiple
+/// raft groups.
+///
+/// # Safety
+///
+/// [`RaftLogStore`] ensure that operations across multiple raft groups are safe. But operations of
+/// a same raft group MUST be performed in order.
 #[derive(Clone)]
 pub struct RaftLogStore {
     core: Arc<RaftLogStoreCore>,
@@ -63,11 +70,21 @@ impl RaftLogStore {
                             len,
                         })
                         .collect_vec();
-                    states.may_add_group(group, first_index).await;
+                    states.may_add_group(group).await;
                     states.append(group, first_index, indices).await?;
                 }
-                Entry::Compact(_) => todo!(),
-                Entry::Kv(_) => todo!(),
+                Entry::Compact(Compact { group, index }) => {
+                    states.may_add_group(group).await;
+                    states.compact(group, index).await?;
+                }
+                Entry::Kv(Kv::Put { group, key, value }) => {
+                    states.may_add_group(group).await;
+                    states.put(group, key, value).await?;
+                }
+                Entry::Kv(Kv::Delete { group, key }) => {
+                    states.may_add_group(group).await;
+                    states.delete(group, key).await?;
+                }
             }
         }
 
@@ -125,6 +142,16 @@ impl RaftLogStore {
         Ok(())
     }
 
+    /// Mark all raft log entries before given `index` of the given `group` can be safely deleted.
+    pub async fn compact(&self, group: u64, index: u64) -> Result<()> {
+        self.core
+            .log
+            .push(Entry::Compact(Compact { group, index }))
+            .await?;
+        self.core.states.compact(group, index).await?;
+        Ok(())
+    }
+
     /// Get raft log entries from [`RaftLogStore`].
     pub async fn entries(&self, group: u64, index: u64, max_len: usize) -> Result<Vec<Vec<u8>>> {
         let indices = self.core.states.entries(group, index, max_len).await?;
@@ -137,16 +164,33 @@ impl RaftLogStore {
         Ok(entries)
     }
 
-    pub async fn put(&self) {
-        todo!()
+    pub async fn put(&self, group: u64, key: Vec<u8>, value: Vec<u8>) -> Result<()> {
+        self.core
+            .log
+            .push(Entry::Kv(Kv::Put {
+                group,
+                key: key.clone(),
+                value: value.clone(),
+            }))
+            .await?;
+        self.core.states.put(group, key, value).await?;
+        Ok(())
     }
 
-    pub async fn delete(&self) {
-        todo!()
+    pub async fn delete(&self, group: u64, key: Vec<u8>) -> Result<()> {
+        self.core
+            .log
+            .push(Entry::Kv(Kv::Delete {
+                group,
+                key: key.clone(),
+            }))
+            .await?;
+        self.core.states.delete(group, key).await?;
+        Ok(())
     }
 
-    pub async fn get(&self) {
-        todo!()
+    pub async fn get(&self, group: u64, key: Vec<u8>) -> Result<Option<Vec<u8>>> {
+        self.core.states.get(group, key).await
     }
 }
 
@@ -198,7 +242,7 @@ mod tests {
         let mut builder = RaftLogBatchBuilder::default();
         for group in 1..=4 {
             for index in 1..=16 {
-                builder.add(group, 1, index, &data(1, index));
+                builder.add(group, 1, index, &data(group, 1, index));
             }
         }
         let batches = builder.build();
@@ -227,7 +271,7 @@ mod tests {
                 entries,
                 (1..=16)
                     .into_iter()
-                    .map(|index| data(1, index))
+                    .map(|index| data(group, 1, index))
                     .collect_vec()
             );
         }
@@ -241,13 +285,111 @@ mod tests {
                 entries,
                 (1..=16)
                     .into_iter()
-                    .map(|index| data(1, index))
+                    .map(|index| data(group, 1, index))
+                    .collect_vec()
+            );
+        }
+
+        for group in 1..=4 {
+            store.compact(group, 9).await.unwrap();
+        }
+        for group in 1..=4 {
+            assert!(store.entries(group, 8, usize::MAX).await.is_err());
+            let entries = store.entries(group, 9, usize::MAX).await.unwrap();
+            assert_eq!(
+                entries,
+                (9..=16)
+                    .into_iter()
+                    .map(|index| data(group, 1, index))
+                    .collect_vec()
+            );
+        }
+
+        drop(store);
+        let store = RaftLogStore::open(options.clone()).await.unwrap();
+        assert_eq!(store.core.log.frozen_file_count().await, 6);
+        for group in 1..=4 {
+            assert!(store.entries(group, 8, usize::MAX).await.is_err());
+            let entries = store.entries(group, 9, usize::MAX).await.unwrap();
+            assert_eq!(
+                entries,
+                (9..=16)
+                    .into_iter()
+                    .map(|index| data(group, 1, index))
                     .collect_vec()
             );
         }
     }
 
-    fn data(term: u64, index: u64) -> Vec<u8> {
-        format!("{:31}-{:32}", term, index).into()
+    #[test(tokio::test)]
+    async fn test_kv() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let options = RaftLogStoreOptions {
+            log_dir_path: tempdir.path().to_str().unwrap().to_string(),
+            // Estimated size of each compressed entry is 111.
+            log_file_capacity: 100,
+            block_cache_capacity: 1024,
+        };
+
+        let store = RaftLogStore::open(options.clone()).await.unwrap();
+        store.add_group(1).await.unwrap();
+        store.add_group(2).await.unwrap();
+        store.add_group(3).await.unwrap();
+        store.add_group(4).await.unwrap();
+
+        for group in 1..=4 {
+            store
+                .put(group, b"k1".to_vec(), b"v1".to_vec())
+                .await
+                .unwrap();
+        }
+
+        for group in 1..=4 {
+            assert_eq!(
+                store.get(group, b"k1".to_vec()).await.unwrap(),
+                Some(b"v1".to_vec())
+            );
+        }
+
+        for group in 1..=4 {
+            store
+                .put(group, b"k1".to_vec(), b"v2".to_vec())
+                .await
+                .unwrap();
+        }
+
+        for group in 1..=4 {
+            assert_eq!(
+                store.get(group, b"k1".to_vec()).await.unwrap(),
+                Some(b"v2".to_vec())
+            );
+        }
+
+        drop(store);
+        let store = RaftLogStore::open(options.clone()).await.unwrap();
+        for group in 1..=4 {
+            assert_eq!(
+                store.get(group, b"k1".to_vec()).await.unwrap(),
+                Some(b"v2".to_vec())
+            );
+        }
+
+        for group in 1..=4 {
+            store.delete(group, b"k1".to_vec()).await.unwrap();
+        }
+
+        for group in 1..=4 {
+            assert_eq!(store.get(group, b"k1".to_vec()).await.unwrap(), None,);
+        }
+
+        drop(store);
+        let store = RaftLogStore::open(options.clone()).await.unwrap();
+        for group in 1..=4 {
+            assert_eq!(store.get(group, b"k1".to_vec()).await.unwrap(), None,);
+        }
+    }
+
+    fn data(group: u64, term: u64, index: u64) -> Vec<u8> {
+        format!("{:15}-{:15}-{:32}", group, term, index).into()
     }
 }


### PR DESCRIPTION
As titled.

Changes:
- Implement compact and kv operations for `RaftLogStore`.

Ref: #88 .