### PR TITLE
feat: introduce async command and gear

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2151,6 +2151,7 @@ dependencies = [
  "runkv-rudder",
  "runkv-storage",
  "runkv-wheel",
+ "tempfile",
  "test-log",
  "tokio",
  "toml",

--- a/etc/wheel.toml
+++ b/etc/wheel.toml
@@ -24,6 +24,11 @@ write_buffer_capacity = "64 MiB"
 block_cache_capacity = "512 MiB"
 meta_cache_capacity = "256 MiB"
 
+[raft_log_store]
+log_dir_path = "/path/to/log/dir"
+log_file_capacity = "64 MiB"
+block_cache_capacity = "256 MiB"
+
 [lsm_tree]
 l1_capacity = "1 MiB"
 level_multiplier = 10

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -21,6 +21,7 @@ runkv-proto = { path = "../proto" }
 runkv-rudder = { path = "../rudder" }
 runkv-storage = { path = "../storage" }
 runkv-wheel = { path = "../wheel" }
+tempfile = "3"
 test-log = "0.2.10"
 tokio = { version = "1", features = [
     "rt-multi-thread",

--- a/tests/etc/wheel.toml
+++ b/tests/etc/wheel.toml
@@ -23,3 +23,8 @@ write_buffer_capacity = "64 KiB"
 [cache]
 block_cache_capacity = "64 KiB"
 meta_cache_capacity = "1 KiB"
+
+[raft_log_store]
+log_dir_path = "/path/to/log/dir"
+log_file_capacity = "64 MiB"
+block_cache_capacity = "256 MiB"

--- a/wheel/src/components/command.rs
+++ b/wheel/src/components/command.rs
@@ -1,0 +1,24 @@
+use runkv_proto::wheel::{KvRequest, KvResponse};
+use tokio::sync::oneshot;
+
+use crate::error::Result;
+
+#[derive(Debug)]
+pub enum CommandRequest {
+    Kv(KvRequest),
+    BuildSnapshot,
+    InstallSnapshot(Vec<u8>),
+}
+
+#[derive(Debug)]
+pub enum CommandResponse {
+    Kv(KvResponse),
+    BuildSnapshot(Vec<u8>),
+    InstallSnapshot,
+}
+
+#[derive(Debug)]
+pub struct AsyncCommand {
+    pub request: CommandRequest,
+    pub response: oneshot::Sender<Result<CommandResponse>>,
+}

--- a/wheel/src/components/fsm.rs
+++ b/wheel/src/components/fsm.rs
@@ -3,15 +3,16 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use runkv_proto::wheel::{KvRequest, KvResponse};
-use tokio::sync::RwLock;
+use tokio::sync::{mpsc, oneshot, RwLock};
 
-use crate::error::Result;
+use super::command::{AsyncCommand, CommandRequest, CommandResponse};
+use crate::error::{Error, Result};
 
 #[async_trait]
 pub trait KvFsm: Send + Sync + Clone + 'static {
     async fn apply(&self, request: &KvRequest) -> Result<KvResponse>;
     async fn build_snapshot(&self) -> Result<Cursor<Vec<u8>>>;
-    async fn apply_snapshot(&self, snapshot: &Cursor<Vec<u8>>) -> Result<()>;
+    async fn install_snapshot(&self, snapshot: &Cursor<Vec<u8>>) -> Result<()>;
 }
 
 #[derive(Clone, Debug)]
@@ -41,9 +42,68 @@ impl KvFsm for MockKvFsm {
         Ok(Cursor::new(buf))
     }
 
-    async fn apply_snapshot(&self, snapshot: &Cursor<Vec<u8>>) -> Result<()> {
+    async fn install_snapshot(&self, snapshot: &Cursor<Vec<u8>>) -> Result<()> {
         let mut state = self.state.write().await;
         *state = snapshot.clone().into_inner();
         Ok(())
+    }
+}
+
+#[derive(Clone)]
+pub struct Gear {
+    sender: mpsc::UnboundedSender<AsyncCommand>,
+}
+
+impl Gear {
+    pub fn new(sender: mpsc::UnboundedSender<AsyncCommand>) -> Self {
+        Self { sender }
+    }
+}
+
+#[async_trait]
+impl KvFsm for Gear {
+    async fn apply(&self, request: &KvRequest) -> Result<KvResponse> {
+        let (tx, rx) = oneshot::channel();
+        self.sender
+            .send(AsyncCommand {
+                request: CommandRequest::Kv(request.to_owned()),
+                response: tx,
+            })
+            .map_err(Error::err)?;
+        let res = rx.await.map_err(Error::err)??;
+        match res {
+            CommandResponse::Kv(kv) => Ok(kv),
+            _ => unreachable!(),
+        }
+    }
+
+    async fn build_snapshot(&self) -> Result<Cursor<Vec<u8>>> {
+        let (tx, rx) = oneshot::channel();
+        self.sender
+            .send(AsyncCommand {
+                request: CommandRequest::BuildSnapshot,
+                response: tx,
+            })
+            .map_err(Error::err)?;
+        let res = rx.await.map_err(Error::err)??;
+        match res {
+            CommandResponse::BuildSnapshot(snapshot) => Ok(Cursor::new(snapshot)),
+            _ => unreachable!(),
+        }
+    }
+
+    async fn install_snapshot(&self, snapshot: &Cursor<Vec<u8>>) -> Result<()> {
+        let (tx, rx) = oneshot::channel();
+        self.sender
+            .send(AsyncCommand {
+                request: CommandRequest::InstallSnapshot(snapshot.to_owned().into_inner()),
+                response: tx,
+            })
+            .map_err(Error::err)?;
+        let res = rx.await.map_err(Error::err)??;
+        match res {
+            CommandResponse::InstallSnapshot => Ok(()),
+            _ => unreachable!(),
+        }
     }
 }

--- a/wheel/src/components/mod.rs
+++ b/wheel/src/components/mod.rs
@@ -1,3 +1,4 @@
+pub mod command;
 pub mod fsm;
 pub mod lsm_tree;
 pub mod network;
@@ -5,8 +6,14 @@ pub mod raft_log_store;
 
 use runkv_proto::wheel::{KvRequest, KvResponse};
 
+use self::fsm::Gear;
+use self::network::RaftNetwork;
+use self::raft_log_store::RaftGroupLogStore;
+
 pub type RaftNodeId = u64;
 
 openraft::declare_raft_types!(
     pub RaftTypeConfig: D = KvRequest, R = Option<KvResponse>, NodeId = RaftNodeId
 );
+
+pub type Raft = openraft::Raft<RaftTypeConfig, RaftNetwork, RaftGroupLogStore<Gear>>;

--- a/wheel/src/components/raft_log_store.rs
+++ b/wheel/src/components/raft_log_store.rs
@@ -363,7 +363,7 @@ impl<F: KvFsm> openraft::RaftStorage<RaftTypeConfig> for RaftGroupLogStore<F> {
         };
 
         self.fsm
-            .apply_snapshot(snapshot.as_ref())
+            .install_snapshot(snapshot.as_ref())
             .await
             .map_err(err)?;
 

--- a/wheel/src/config.rs
+++ b/wheel/src/config.rs
@@ -16,9 +16,17 @@ pub struct WheelConfig {
     pub buffer: BufferConfig,
     pub cache: CacheConfig,
     pub lsm_tree: LsmTreeConfig,
+    pub raft_log_store: RaftLogStoreConfig,
 }
 
 #[derive(Deserialize, Clone, Debug)]
 pub struct BufferConfig {
     pub write_buffer_capacity: String,
+}
+
+#[derive(Deserialize, Clone, Debug)]
+pub struct RaftLogStoreConfig {
+    pub log_dir_path: String,
+    pub log_file_capacity: String,
+    pub block_cache_capacity: String,
 }

--- a/wheel/src/service.rs
+++ b/wheel/src/service.rs
@@ -6,6 +6,7 @@ use runkv_proto::wheel::{
     AppendEntriesRequest, AppendEntriesResponse, InstallSnapshotRequest, InstallSnapshotResponse,
     UpdateKeyRangesRequest, UpdateKeyRangesResponse, VoteRequest, VoteResponse,
 };
+use runkv_storage::raft_log_store::RaftLogStore;
 use tonic::{Request, Response, Status};
 
 use crate::components::lsm_tree::ObjectStoreLsmTree;
@@ -19,12 +20,14 @@ pub struct WheelOptions {
     pub lsm_tree: ObjectStoreLsmTree,
     pub meta_store: MetaStoreRef,
     pub channel_pool: ChannelPool,
+    pub raft_log_store: RaftLogStore,
 }
 
 pub struct Wheel {
     _lsm_tree: ObjectStoreLsmTree,
     meta_store: MetaStoreRef,
     _channel_pool: ChannelPool,
+    _raft_log_store: RaftLogStore,
 }
 
 impl Wheel {
@@ -33,6 +36,7 @@ impl Wheel {
             _lsm_tree: options.lsm_tree,
             meta_store: options.meta_store,
             _channel_pool: options.channel_pool,
+            _raft_log_store: options.raft_log_store,
         }
     }
 }


### PR DESCRIPTION
`Gear` is used to forward commands from to the `ObjectLsmTree` asynchronously.

Part of work to combine raft log store and state machine WAL.

Ref: #88 .