### PR TITLE
feat: introduce raft manager (skeleton)

### DIFF
--- a/proto/src/proto/wheel.proto
+++ b/proto/src/proto/wheel.proto
@@ -60,27 +60,33 @@ service WheelService {
 }
 
 message AppendEntriesRequest {
-  bytes data = 1;
+  uint64 id = 1;
+  bytes data = 2;
 }
 
 message AppendEntriesResponse {
-  bytes data = 1;
+  uint64 id = 1;
+  bytes data = 2;
 }
 
 message InstallSnapshotRequest {
-  bytes data = 1;
+  uint64 id = 1;
+  bytes data = 2;
 }
 
 message InstallSnapshotResponse {
-  bytes data = 1;
+  uint64 id = 1;
+  bytes data = 2;
 }
 
 message VoteRequest {
-  bytes data = 1;
+  uint64 id = 1;
+  bytes data = 2;
 }
 
 message VoteResponse {
-  bytes data = 1;
+  uint64 id = 1;
+  bytes data = 2;
 }
 
 service RaftService {

--- a/wheel/src/components/fsm.rs
+++ b/wheel/src/components/fsm.rs
@@ -2,11 +2,10 @@ use std::io::Cursor;
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use parking_lot::RwLock;
 use runkv_proto::wheel::{KvRequest, KvResponse};
-use tokio::sync::{mpsc, oneshot, RwLock};
 
-use super::command::{AsyncCommand, CommandRequest, CommandResponse};
-use crate::error::{Error, Result};
+use crate::error::Result;
 
 #[async_trait]
 pub trait KvFsm: Send + Sync + Clone + 'static {
@@ -31,79 +30,20 @@ impl Default for MockKvFsm {
 #[async_trait]
 impl KvFsm for MockKvFsm {
     async fn apply(&self, request: &KvRequest) -> Result<KvResponse> {
-        let mut state = self.state.write().await;
+        let mut state = self.state.write();
         *state = bincode::serialize(request).unwrap();
         Ok(KvResponse { ops: vec![] })
     }
 
     async fn build_snapshot(&self) -> Result<Cursor<Vec<u8>>> {
-        let state = self.state.read().await;
+        let state = self.state.read();
         let buf = (*state).clone();
         Ok(Cursor::new(buf))
     }
 
     async fn install_snapshot(&self, snapshot: &Cursor<Vec<u8>>) -> Result<()> {
-        let mut state = self.state.write().await;
+        let mut state = self.state.write();
         *state = snapshot.clone().into_inner();
         Ok(())
-    }
-}
-
-#[derive(Clone)]
-pub struct Gear {
-    sender: mpsc::UnboundedSender<AsyncCommand>,
-}
-
-impl Gear {
-    pub fn new(sender: mpsc::UnboundedSender<AsyncCommand>) -> Self {
-        Self { sender }
-    }
-}
-
-#[async_trait]
-impl KvFsm for Gear {
-    async fn apply(&self, request: &KvRequest) -> Result<KvResponse> {
-        let (tx, rx) = oneshot::channel();
-        self.sender
-            .send(AsyncCommand {
-                request: CommandRequest::Kv(request.to_owned()),
-                response: tx,
-            })
-            .map_err(Error::err)?;
-        let res = rx.await.map_err(Error::err)??;
-        match res {
-            CommandResponse::Kv(kv) => Ok(kv),
-            _ => unreachable!(),
-        }
-    }
-
-    async fn build_snapshot(&self) -> Result<Cursor<Vec<u8>>> {
-        let (tx, rx) = oneshot::channel();
-        self.sender
-            .send(AsyncCommand {
-                request: CommandRequest::BuildSnapshot,
-                response: tx,
-            })
-            .map_err(Error::err)?;
-        let res = rx.await.map_err(Error::err)??;
-        match res {
-            CommandResponse::BuildSnapshot(snapshot) => Ok(Cursor::new(snapshot)),
-            _ => unreachable!(),
-        }
-    }
-
-    async fn install_snapshot(&self, snapshot: &Cursor<Vec<u8>>) -> Result<()> {
-        let (tx, rx) = oneshot::channel();
-        self.sender
-            .send(AsyncCommand {
-                request: CommandRequest::InstallSnapshot(snapshot.to_owned().into_inner()),
-                response: tx,
-            })
-            .map_err(Error::err)?;
-        let res = rx.await.map_err(Error::err)??;
-        match res {
-            CommandResponse::InstallSnapshot => Ok(()),
-            _ => unreachable!(),
-        }
     }
 }

--- a/wheel/src/components/mod.rs
+++ b/wheel/src/components/mod.rs
@@ -1,12 +1,14 @@
 pub mod command;
 pub mod fsm;
+pub mod gear;
 pub mod lsm_tree;
 pub mod network;
 pub mod raft_log_store;
+pub mod raft_manager;
 
 use runkv_proto::wheel::{KvRequest, KvResponse};
 
-use self::fsm::Gear;
+use self::gear::Gear;
 use self::network::RaftNetwork;
 use self::raft_log_store::RaftGroupLogStore;
 

--- a/wheel/src/components/raft_manager.rs
+++ b/wheel/src/components/raft_manager.rs
@@ -1,0 +1,79 @@
+use std::collections::btree_map::{BTreeMap, Entry};
+use std::sync::Arc;
+
+use runkv_storage::raft_log_store::RaftLogStore;
+use tokio::sync::RwLock;
+
+use super::gear::Gear;
+use super::network::RaftNetwork;
+use super::raft_log_store::RaftGroupLogStore;
+use super::Raft;
+use crate::error::{RaftError, Result};
+
+pub struct RaftManagerOptions {
+    pub raft_log_store: RaftLogStore,
+    pub raft_network: RaftNetwork,
+    pub gear: Gear,
+    pub node: u64,
+}
+
+pub struct RaftManager {
+    _node: u64,
+    raft_log_store: RaftLogStore,
+    raft_network: RaftNetwork,
+    gear: Gear,
+    rafts: Arc<RwLock<BTreeMap<u64, Raft>>>,
+}
+
+impl RaftManager {
+    pub fn new(options: RaftManagerOptions) -> Self {
+        Self {
+            _node: options.node,
+            raft_log_store: options.raft_log_store,
+            raft_network: options.raft_network,
+            gear: options.gear,
+            rafts: Arc::new(RwLock::new(BTreeMap::default())),
+        }
+    }
+
+    pub async fn add_raft_group(
+        &self,
+        group: u64,
+        raft_node: u64,
+        raft_nodes: BTreeMap<u64, u64>,
+    ) -> Result<()> {
+        let mut rafts = self.rafts.write().await;
+        match rafts.entry(raft_node) {
+            Entry::Occupied(_) => Err(RaftError::RaftNodeAlreadyExists {
+                group,
+                node: raft_node,
+            }
+            .into()),
+            Entry::Vacant(v) => {
+                for (raft_node, node) in raft_nodes.iter() {
+                    self.raft_network.update_raft_node(*node, *raft_node)?;
+                }
+                let network = self.raft_network.clone();
+                let storage =
+                    RaftGroupLogStore::new(group, self.raft_log_store.clone(), self.gear.clone());
+                let config = openraft::Config {
+                    cluster_name: format!("raft-group-{}", group),
+                    // election_timeout_min: todo!(),
+                    // election_timeout_max: todo!(),
+                    // heartbeat_interval: todo!(),
+                    // install_snapshot_timeout: todo!(),
+                    // max_payload_entries: todo!(),
+                    // replication_lag_threshold: todo!(),
+                    // snapshot_policy: todo!(),
+                    // snapshot_max_chunk_size: todo!(),
+                    // max_applied_log_to_keep: todo!(),
+                    ..Default::default()
+                };
+                let config = Arc::new(config);
+                let raft = Raft::new(raft_node, config, network, storage);
+                v.insert(raft);
+                Ok(())
+            }
+        }
+    }
+}

--- a/wheel/src/error.rs
+++ b/wheel/src/error.rs
@@ -12,6 +12,8 @@ pub enum Error {
     RpcStatus(#[from] Status),
     #[error("serde error: {0}")]
     SerdeError(String),
+    #[error("raft error: {0}")]
+    RaftError(#[from] RaftError),
     #[error("other: {0}")]
     Other(String),
 }
@@ -32,6 +34,18 @@ impl Error {
     pub fn serde_err(e: impl Into<Box<dyn std::error::Error>>) -> Error {
         Self::SerdeError(e.into().to_string())
     }
+
+    pub fn status(s: Status) -> Error {
+        Self::RpcStatus(s)
+    }
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
+
+#[derive(thiserror::Error, Debug)]
+pub enum RaftError {
+    #[error("raft node not exists: [group: {group}] [node: {node}]")]
+    RaftNodeNotExists { group: u64, node: u64 },
+    #[error("raft node already exists: [group: {group}] [node: {node}]")]
+    RaftNodeAlreadyExists { group: u64, node: u64 },
+}

--- a/wheel/src/service.rs
+++ b/wheel/src/service.rs
@@ -7,9 +7,13 @@ use runkv_proto::wheel::{
     UpdateKeyRangesRequest, UpdateKeyRangesResponse, VoteRequest, VoteResponse,
 };
 use runkv_storage::raft_log_store::RaftLogStore;
+use tokio::sync::mpsc;
 use tonic::{Request, Response, Status};
 
+use crate::components::command::AsyncCommand;
 use crate::components::lsm_tree::ObjectStoreLsmTree;
+use crate::components::network::RaftNetwork;
+use crate::components::raft_manager::RaftManager;
 use crate::meta::MetaStoreRef;
 
 fn internal(e: impl Into<Box<dyn std::error::Error>>) -> Status {
@@ -21,6 +25,9 @@ pub struct WheelOptions {
     pub meta_store: MetaStoreRef,
     pub channel_pool: ChannelPool,
     pub raft_log_store: RaftLogStore,
+    pub raft_network: RaftNetwork,
+    pub raft_manager: RaftManager,
+    pub gear_receiver: mpsc::UnboundedReceiver<AsyncCommand>,
 }
 
 pub struct Wheel {
@@ -28,6 +35,9 @@ pub struct Wheel {
     meta_store: MetaStoreRef,
     _channel_pool: ChannelPool,
     _raft_log_store: RaftLogStore,
+    _raft_network: RaftNetwork,
+    _raft_manager: RaftManager,
+    _gear_receiver: mpsc::UnboundedReceiver<AsyncCommand>,
 }
 
 impl Wheel {
@@ -37,6 +47,9 @@ impl Wheel {
             meta_store: options.meta_store,
             _channel_pool: options.channel_pool,
             _raft_log_store: options.raft_log_store,
+            _raft_network: options.raft_network,
+            _raft_manager: options.raft_manager,
+            _gear_receiver: options.gear_receiver,
         }
     }
 }


### PR DESCRIPTION
`RaftManager` is for managing multiple raft groups. This pr only implements its skeleton.

Ref: #88 .