### PR TITLE
feat: separate apply and snapshot cmd channel

### DIFF
--- a/storage/src/lsm_tree/mod.rs
+++ b/storage/src/lsm_tree/mod.rs
@@ -10,39 +10,3 @@ pub const DEFAULT_ENTRY_SIZE: usize = 1024; // 1 KiB
 pub const DEFAULT_BLOOM_FALSE_POSITIVE: f64 = 0.1;
 pub const DEFAULT_SSTABLE_META_SIZE: usize = 4 * 1024; // 4 KiB
 pub const DEFAULT_MEMTABLE_SIZE: usize = 4 * 1024 * 1024; // 4 MiB
-
-use async_trait::async_trait;
-use bytes::Bytes;
-
-use crate::error::Result;
-
-// TODO: Support iterator on [`LsmTree`].
-#[async_trait]
-pub trait LsmTree: Send + Sync + Clone + 'static {
-    /// Put a new `key` `value` pair into LSM-Tree with given `timestamp`.
-    ///
-    /// # Safety
-    ///
-    /// The interface exposes `timestamp` to user for the compatibility with upper system. It's
-    /// caller's responsibility to ensure that the new timestamp is higher than the old one on the
-    /// same key. Otherwise there will be consistency problems.
-    async fn put(&self, key: &Bytes, value: &Bytes, timestamp: u64) -> Result<()>;
-
-    /// Delete a the given `key` in LSM-Tree by tombstone with given `timestamp`.
-    ///
-    /// # Safety
-    ///
-    /// The interface exposes `timestamp` to user for the compatibility with upper system. It's
-    /// caller's responsibility to ensure that the new timestamp is higher than the old one on the
-    /// same key. Otherwise there will be consistency problems.
-    async fn delete(&self, key: &Bytes, timestamp: u64) -> Result<()>;
-
-    /// Get the value of the given `key` in LSM-Tree with given `timestamp`.
-    ///
-    /// # Safety
-    ///
-    /// The interface exposes `timestamp` to user for the compatibility with upper system. It's
-    /// caller's responsibility to ensure that the new timestamp is higher than the old one on the
-    /// same key. Otherwise there will be consistency problems.
-    async fn get(&self, key: &Bytes, timestamp: u64) -> Result<Option<Bytes>>;
-}

--- a/tests/integrations/mod.rs
+++ b/tests/integrations/mod.rs
@@ -13,7 +13,7 @@ use runkv_proto::meta::KeyRange;
 use runkv_proto::wheel::wheel_service_client::WheelServiceClient;
 use runkv_rudder::config::RudderConfig;
 use runkv_rudder::{bootstrap_rudder, build_rudder_with_object_store};
-use runkv_storage::{LsmTree, MemObjectStore};
+use runkv_storage::MemObjectStore;
 use runkv_wheel::config::WheelConfig;
 use runkv_wheel::{bootstrap_wheel, build_wheel_with_object_store};
 use test_log::test;
@@ -97,19 +97,25 @@ async fn test_concurrent_put_get() {
             async move {
                 let mut rng = thread_rng();
                 tokio::time::sleep(Duration::from_millis(rng.gen_range(0..100))).await;
-                lsmtree_clone.put(&key(i), &value(i), 1).await.unwrap();
+                lsmtree_clone
+                    .put(&key(i), &value(i), 1, 0, 0)
+                    .await
+                    .unwrap();
                 trace!("put {:?} at {}", key(i), 1);
                 tokio::time::sleep(Duration::from_millis(rng.gen_range(0..100))).await;
                 trace!("get {:?} at {}", key(i), 3);
                 assert_eq!(lsmtree_clone.get(&key(i), 3).await.unwrap(), Some(value(i)));
                 tokio::time::sleep(Duration::from_millis(rng.gen_range(0..100))).await;
-                lsmtree_clone.delete(&key(i), 5).await.unwrap();
+                lsmtree_clone.delete(&key(i), 5, 0, 0).await.unwrap();
                 trace!("delete {:?} at {}", key(i), 5);
                 tokio::time::sleep(Duration::from_millis(rng.gen_range(0..100))).await;
                 trace!("get {:?} at {}", key(i), 7);
                 assert_eq!(lsmtree_clone.get(&key(i), 7).await.unwrap(), None);
                 tokio::time::sleep(Duration::from_millis(rng.gen_range(0..100))).await;
-                lsmtree_clone.put(&key(i), &value(i), 9).await.unwrap();
+                lsmtree_clone
+                    .put(&key(i), &value(i), 9, 0, 0)
+                    .await
+                    .unwrap();
                 trace!("put {:?} at {}", key(i), 9);
                 tokio::time::sleep(Duration::from_millis(rng.gen_range(0..100))).await;
                 trace!("get {:?} at {}", key(i), 11);

--- a/wheel/src/components/command.rs
+++ b/wheel/src/components/command.rs
@@ -1,44 +1,24 @@
+use std::ops::Range;
+
 use tokio::sync::oneshot;
 
-use crate::error::Result;
-
 #[derive(Debug)]
-pub enum CommandRequest {
-    Data {
-        group: u64,
-        index: u64,
-        data: Vec<u8>,
-    },
-    BuildSnapshot {
-        group: u64,
-        index: u64,
-    },
-    InstallSnapshot {
-        group: u64,
-        index: u64,
-        snapshot: Vec<u8>,
-    },
+pub struct Apply {
+    pub group: u64,
+    pub range: Range<u64>,
 }
 
 #[derive(Debug)]
-pub enum CommandResponse {
-    Data {
+pub enum Snapshot {
+    Build {
         group: u64,
         index: u64,
+        notifier: oneshot::Sender<Vec<u8>>,
     },
-    BuildSnapshot {
+    Install {
         group: u64,
         index: u64,
         snapshot: Vec<u8>,
+        notifier: oneshot::Sender<()>,
     },
-    InstallSnapshot {
-        group: u64,
-        index: u64,
-    },
-}
-
-#[derive(Debug)]
-pub struct AsyncCommand {
-    pub request: CommandRequest,
-    pub response: oneshot::Sender<Result<CommandResponse>>,
 }

--- a/wheel/src/components/gear.rs
+++ b/wheel/src/components/gear.rs
@@ -1,60 +1,63 @@
 use std::io::Cursor;
+use std::ops::Range;
 
 use async_trait::async_trait;
 use tokio::sync::{mpsc, oneshot};
 use tracing::trace;
 
-use super::command::{AsyncCommand, CommandRequest, CommandResponse};
+use super::command::{Apply, Snapshot};
 use super::fsm::Fsm;
 use crate::error::{Error, Result};
 
 #[derive(Clone)]
 pub struct Gear {
-    sender: mpsc::UnboundedSender<AsyncCommand>,
+    apply_tx: mpsc::UnboundedSender<Apply>,
+    snapshot_tx: mpsc::UnboundedSender<Snapshot>,
 }
 
 impl Gear {
-    pub fn new(sender: mpsc::UnboundedSender<AsyncCommand>) -> Self {
-        Self { sender }
+    pub fn new(
+        apply_tx: mpsc::UnboundedSender<Apply>,
+        snapshot_tx: mpsc::UnboundedSender<Snapshot>,
+    ) -> Self {
+        Self {
+            apply_tx,
+            snapshot_tx,
+        }
     }
 }
 
 #[async_trait]
 impl Fsm for Gear {
-    async fn apply(&self, group: u64, index: u64, request: &[u8]) -> Result<()> {
-        trace!(group = group, index = index, "notify apply:");
-        let (tx, rx) = oneshot::channel();
-        self.sender
-            .send(AsyncCommand {
-                request: CommandRequest::Data {
-                    group,
-                    index,
-                    data: request.to_vec(),
-                },
-                response: tx,
-            })
+    async fn apply(&self, _group: u64, _index: u64, _request: &[u8]) -> Result<()> {
+        Ok(())
+    }
+
+    async fn post_apply(&self, group: u64, range: Range<u64>) -> Result<()> {
+        trace!(
+            "notify apply: [group: {}] [range: [{}..{})]",
+            group,
+            range.start,
+            range.end
+        );
+        self.apply_tx
+            .send(Apply { group, range })
             .map_err(Error::err)?;
-        let res = rx.await.map_err(Error::err)??;
-        match res {
-            CommandResponse::Data { .. } => Ok(()),
-            _ => unreachable!(),
-        }
+        Ok(())
     }
 
     async fn build_snapshot(&self, group: u64, index: u64) -> Result<Cursor<Vec<u8>>> {
         trace!("build snapshot");
         let (tx, rx) = oneshot::channel();
-        self.sender
-            .send(AsyncCommand {
-                request: CommandRequest::BuildSnapshot { group, index },
-                response: tx,
+        self.snapshot_tx
+            .send(Snapshot::Build {
+                group,
+                index,
+                notifier: tx,
             })
             .map_err(Error::err)?;
-        let res = rx.await.map_err(Error::err)??;
-        match res {
-            CommandResponse::BuildSnapshot { snapshot, .. } => Ok(Cursor::new(snapshot)),
-            _ => unreachable!(),
-        }
+        let snapshot = rx.await.map_err(Error::err)?;
+        Ok(Cursor::new(snapshot))
     }
 
     async fn install_snapshot(
@@ -65,20 +68,15 @@ impl Fsm for Gear {
     ) -> Result<()> {
         trace!("install snapshot: {:?}", snapshot);
         let (tx, rx) = oneshot::channel();
-        self.sender
-            .send(AsyncCommand {
-                request: CommandRequest::InstallSnapshot {
-                    group,
-                    index,
-                    snapshot: snapshot.to_owned().into_inner(),
-                },
-                response: tx,
+        self.snapshot_tx
+            .send(Snapshot::Install {
+                group,
+                index,
+                snapshot: snapshot.to_owned().into_inner(),
+                notifier: tx,
             })
             .map_err(Error::err)?;
-        let res = rx.await.map_err(Error::err)??;
-        match res {
-            CommandResponse::InstallSnapshot { .. } => Ok(()),
-            _ => unreachable!(),
-        }
+        rx.await.map_err(Error::err)?;
+        Ok(())
     }
 }

--- a/wheel/src/components/lsm_tree.rs
+++ b/wheel/src/components/lsm_tree.rs
@@ -1,9 +1,6 @@
-use std::cell::RefCell;
-use std::collections::VecDeque;
-use std::marker::PhantomData;
+use std::collections::{BTreeMap, VecDeque};
 use std::sync::Arc;
 
-use async_trait::async_trait;
 use bytes::Bytes;
 use parking_lot::RwLock;
 use runkv_common::config::LevelCompactionStrategy;
@@ -13,7 +10,7 @@ use runkv_storage::components::{
 use runkv_storage::iterator::{Iterator, MergeIterator, Seek, SstableIterator, UserKeyIterator};
 use runkv_storage::manifest::VersionManager;
 use runkv_storage::utils::value;
-use runkv_storage::{LsmTree, Result};
+use runkv_storage::Result;
 use tracing::trace;
 
 #[derive(Clone)]
@@ -26,49 +23,72 @@ pub struct ObjectStoreLsmTreeOptions {
     pub version_manager: VersionManager,
 }
 
-pub struct ObjectStoreLsmTreeCore {
+pub struct MemtableWithCtx {
+    pub table: Memtable,
+    /// `{ raft group -> index }`
+    pub ctx: BTreeMap<u64, u64>,
+}
+
+impl MemtableWithCtx {
+    fn new(capacity: usize) -> Self {
+        Self {
+            table: Memtable::new(capacity),
+            ctx: BTreeMap::default(),
+        }
+    }
+}
+
+struct Memtables {
+    memtable: MemtableWithCtx,
+    immutable_memtables: VecDeque<MemtableWithCtx>,
+}
+
+struct ObjectStoreLsmTreeCore {
     /// Options.
     options: ObjectStoreLsmTreeOptions,
-    /// Current mutable memtable.
-    memtable: RefCell<Memtable>,
-    /// Immutable memtabls, waiting to be uploaded to S3.
-    immutable_memtables: RefCell<VecDeque<Memtable>>,
+
     version_manager: VersionManager,
     sstable_store: SstableStoreRef,
-    /// Use a external lock to tighten the critical section.
-    rwlock: RwLock<PhantomData<Memtable>>,
+
+    memtables: RwLock<Memtables>,
+    // ----- critical section protected by rwlock -----
+    // /// Current mutable memtable.
+    // memtable: RefCell<Memtable>,
+    // /// Immutable memtabls, waiting to be uploaded to S3.
+    // immutable_memtables: RefCell<VecDeque<Memtable>>,
+    // /// Use a external lock to tighten the critical section.
+    // rwlock: RwLock<PhantomData<Memtable>>,
+    // ----- critical section protected by rwlock -----
 }
 
 impl ObjectStoreLsmTreeCore {
     pub fn new(options: ObjectStoreLsmTreeOptions) -> Self {
-        let memtable = RefCell::new(Memtable::new(options.write_buffer_capacity));
-        let immutable_memtables = RefCell::new(VecDeque::with_capacity(32));
         Self {
-            memtable,
-            immutable_memtables,
             version_manager: options.version_manager.clone(),
             sstable_store: options.sstable_store.clone(),
-            rwlock: RwLock::new(PhantomData),
+
+            memtables: RwLock::new(Memtables {
+                memtable: MemtableWithCtx::new(options.write_buffer_capacity),
+                immutable_memtables: VecDeque::with_capacity(32),
+            }),
+
             options,
         }
-    }
-
-    async fn put(&self, key: &Bytes, value: &Bytes, timestamp: u64) -> Result<()> {
-        self.write(key, Some(value), timestamp).await
-    }
-
-    async fn delete(&self, key: &Bytes, timestamp: u64) -> Result<()> {
-        self.write(key, None, timestamp).await
     }
 
     async fn get(&self, key: &Bytes, timestamp: u64) -> Result<Option<Bytes>> {
         // Prevent current memtable and immutable memtable vec being modified.
         let memtables = {
-            let guard = self.rwlock.read();
-            let imms = self.immutable_memtables.borrow();
-            let mut memtables = Vec::with_capacity(imms.len() + 1);
-            memtables.push(self.memtable.borrow().clone());
-            memtables.extend(imms.clone().drain(..));
+            let guard = self.memtables.read();
+            let mut memtables = Vec::with_capacity(guard.immutable_memtables.len() + 1);
+            memtables.push(guard.memtable.table.clone());
+            memtables.extend(
+                guard
+                    .immutable_memtables
+                    .iter()
+                    .map(|memtable| &memtable.table)
+                    .cloned(),
+            );
             drop(guard);
             memtables
         };
@@ -141,7 +161,14 @@ impl ObjectStoreLsmTreeCore {
         Ok(None)
     }
 
-    async fn write(&self, key: &Bytes, value: Option<&Bytes>, timestamp: u64) -> Result<()> {
+    async fn write(
+        &self,
+        key: &Bytes,
+        value: Option<&Bytes>,
+        timestamp: u64,
+        group: u64,
+        index: u64,
+    ) -> Result<()> {
         // = key len + value len
         // + skiplist node height (8B) + skiplist node tower (4 * MAX)
         // + reserved (8B)
@@ -161,33 +188,38 @@ impl ObjectStoreLsmTreeCore {
         //     approximate_size
         // );
 
-        // Rotate active memtable within lock guard.
-        if self.memtable.borrow().mem_remain() < approximate_size {
-            let guard = self.rwlock.write();
-            // println!("rotate memtable");
-            let imm = self.memtable.borrow().clone();
-            *self.memtable.borrow_mut() = Memtable::new(self.options.write_buffer_capacity);
-            self.immutable_memtables.borrow_mut().push_front(imm);
-            drop(guard);
+        let mut guard = self.memtables.write();
+        // Rotate memtable if needed.
+        if guard.memtable.table.mem_remain() < approximate_size {
+            trace!("rotate memtable");
+            let mut imm = MemtableWithCtx::new(self.options.write_buffer_capacity);
+            std::mem::swap(&mut imm, &mut guard.memtable);
+            guard.immutable_memtables.push_front(imm);
         }
+        guard.memtable.table.put(key, value, timestamp);
+        *guard.memtable.ctx.entry(group).or_default() = index;
+        drop(guard);
 
-        self.memtable.borrow_mut().put(key, value, timestamp);
         Ok(())
     }
 
     fn get_oldest_immutable_memtable(&self) -> Option<Memtable> {
-        let guard = self.rwlock.read();
-        let imm = self.immutable_memtables.borrow().back().cloned();
-        drop(guard);
-        imm
+        self.memtables
+            .read()
+            .immutable_memtables
+            .back()
+            .map(|memtable| &memtable.table)
+            .cloned()
     }
 
-    fn drop_oldest_immutable_memtable(&self) {
-        let guard = self.rwlock.write();
-        let mut imms = self.immutable_memtables.borrow_mut();
-        assert!(!imms.is_empty());
-        imms.pop_back();
-        drop(guard);
+    fn drop_oldest_immutable_memtable(&self) -> MemtableWithCtx {
+        let imm = self
+            .memtables
+            .write()
+            .immutable_memtables
+            .pop_back()
+            .unwrap();
+        imm
     }
 }
 
@@ -198,21 +230,6 @@ pub struct ObjectStoreLsmTree {
     inner: Arc<ObjectStoreLsmTreeCore>,
 }
 
-#[async_trait]
-impl LsmTree for ObjectStoreLsmTree {
-    async fn put(&self, key: &Bytes, value: &Bytes, timestamp: u64) -> Result<()> {
-        self.inner.put(key, value, timestamp).await
-    }
-
-    async fn delete(&self, key: &Bytes, timestamp: u64) -> Result<()> {
-        self.inner.delete(key, timestamp).await
-    }
-
-    async fn get(&self, key: &Bytes, timestamp: u64) -> Result<Option<Bytes>> {
-        self.inner.get(key, timestamp).await
-    }
-}
-
 impl ObjectStoreLsmTree {
     pub fn new(options: ObjectStoreLsmTreeOptions) -> Self {
         Self {
@@ -220,11 +237,53 @@ impl ObjectStoreLsmTree {
         }
     }
 
+    /// Put a new `key` `value` pair into LSM-Tree with given `timestamp`.
+    ///
+    /// # Safety
+    ///
+    /// The interface exposes `timestamp` to user for the compatibility with upper system. It's
+    /// caller's responsibility to ensure that the new timestamp is higher than the old one on the
+    /// same key. Otherwise there will be consistency problems.
+    pub async fn put(
+        &self,
+        key: &Bytes,
+        value: &Bytes,
+        timestamp: u64,
+        group: u64,
+        index: u64,
+    ) -> Result<()> {
+        self.inner
+            .write(key, Some(value), timestamp, group, index)
+            .await
+    }
+
+    /// Delete a the given `key` in LSM-Tree by tombstone with given `timestamp`.
+    ///
+    /// # Safety
+    ///
+    /// The interface exposes `timestamp` to user for the compatibility with upper system. It's
+    /// caller's responsibility to ensure that the new timestamp is higher than the old one on the
+    /// same key. Otherwise there will be consistency problems.
+    pub async fn delete(&self, key: &Bytes, timestamp: u64, group: u64, index: u64) -> Result<()> {
+        self.inner.write(key, None, timestamp, group, index).await
+    }
+
+    /// Get the value of the given `key` in LSM-Tree with given `timestamp`.
+    ///
+    /// # Safety
+    ///
+    /// The interface exposes `timestamp` to user for the compatibility with upper system. It's
+    /// caller's responsibility to ensure that the new timestamp is higher than the old one on the
+    /// same key. Otherwise there will be consistency problems.
+    pub async fn get(&self, key: &Bytes, timestamp: u64) -> Result<Option<Bytes>> {
+        self.inner.get(key, timestamp).await
+    }
+
     pub fn get_oldest_immutable_memtable(&self) -> Option<Memtable> {
         self.inner.get_oldest_immutable_memtable()
     }
 
-    pub fn drop_oldest_immutable_memtable(&self) {
+    pub fn drop_oldest_immutable_memtable(&self) -> MemtableWithCtx {
         self.inner.drop_oldest_immutable_memtable()
     }
 }

--- a/wheel/src/worker/kv.rs
+++ b/wheel/src/worker/kv.rs
@@ -1,28 +1,42 @@
 use async_trait::async_trait;
 use runkv_common::Worker;
 use tokio::sync::mpsc;
-use tracing::{trace, warn};
+use tracing::warn;
 
-use crate::components::command::{AsyncCommand, CommandRequest, CommandResponse};
+use crate::components::command::{Apply, Snapshot};
 use crate::components::gear::Gear;
 use crate::components::lsm_tree::ObjectStoreLsmTree;
+use crate::components::raft_log_store::RaftGroupLogStore;
 use crate::components::Raft;
-use crate::error::Result;
+use crate::error::{Error, Result};
+
+/// Done index (exclusive).
+pub const DONE_INDEX_KEY: &[u8] = b"done_index";
+/// Available index (exclusive).
+pub const AVAILABLE_INDEX_KEY: &[u8] = b"available_index";
 
 pub struct KvWorkerOptions {
     pub group: u64,
     pub raft_node: u64,
+    pub available_index: u64,
+    pub done_index: u64,
+    pub raft_group_log_store: RaftGroupLogStore<Gear>,
     pub lsm_tree: ObjectStoreLsmTree,
     pub raft: Raft<Gear>,
-    pub rx: mpsc::UnboundedReceiver<AsyncCommand>,
+    pub apply_rx: mpsc::UnboundedReceiver<Apply>,
+    pub snapshot_rx: mpsc::UnboundedReceiver<Snapshot>,
 }
 
 pub struct KvWorker {
-    _group: u64,
-    _raft_node: u64,
-    _lsm_tree: ObjectStoreLsmTree,
-    _raft: Raft<Gear>,
-    rx: mpsc::UnboundedReceiver<AsyncCommand>,
+    group: u64,
+    raft_node: u64,
+    raft_group_log_store: RaftGroupLogStore<Gear>,
+    lsm_tree: ObjectStoreLsmTree,
+    raft: Raft<Gear>,
+    available_index: u64,
+    done_index: u64,
+    apply_rx: mpsc::UnboundedReceiver<Apply>,
+    snapshot_rx: mpsc::UnboundedReceiver<Snapshot>,
 }
 
 #[async_trait]
@@ -31,7 +45,7 @@ impl Worker for KvWorker {
         // TODO: Gracefully kill.
         loop {
             match self.run_inner().await {
-                Ok(_) => {}
+                Ok(_) => return Ok(()),
                 Err(e) => warn!("error occur when uploader running: {}", e),
             }
         }
@@ -41,37 +55,100 @@ impl Worker for KvWorker {
 impl KvWorker {
     pub fn new(options: KvWorkerOptions) -> Self {
         Self {
-            _group: options.group,
-            _raft_node: options.raft_node,
-            _lsm_tree: options.lsm_tree,
-            _raft: options.raft,
-            rx: options.rx,
+            group: options.group,
+            raft_node: options.raft_node,
+            raft_group_log_store: options.raft_group_log_store,
+            lsm_tree: options.lsm_tree,
+            raft: options.raft,
+            available_index: options.available_index,
+            done_index: options.done_index,
+            apply_rx: options.apply_rx,
+            snapshot_rx: options.snapshot_rx,
         }
     }
 
     async fn run_inner(&mut self) -> Result<()> {
-        // TODO: Handle cmd.
-        while let Some(cmd) = self.rx.recv().await {
-            trace!("receive cmd: {:?}", cmd);
-            let rsp = match cmd.request {
-                CommandRequest::Data {
-                    group,
-                    index,
-                    data: _,
-                } => CommandResponse::Data { group, index },
-                CommandRequest::BuildSnapshot { group, index } => CommandResponse::BuildSnapshot {
-                    group,
-                    index,
-                    snapshot: vec![],
-                },
-                CommandRequest::InstallSnapshot {
-                    group,
-                    index,
-                    snapshot: _,
-                } => CommandResponse::InstallSnapshot { group, index },
-            };
-            cmd.response.send(Ok(rsp)).unwrap();
+        loop {
+            tokio::select! {
+                biased;
+
+                Some(snapshot) = self.snapshot_rx.recv() => {
+                    self.handle_snapshot(snapshot).await?;
+                }
+                Some(apply) = self.apply_rx.recv() => {
+                    self.handle_apply(apply).await?;
+                }
+                else => return Ok(()),
+            }
+        }
+    }
+
+    async fn handle_apply(&mut self, apply: Apply) -> Result<()> {
+        debug_assert_eq!(self.group, apply.group);
+        assert!(self.available_index <= apply.range.end);
+        self.available_index = apply.range.end;
+        Ok(())
+    }
+
+    async fn handle_snapshot(&mut self, snapshot: Snapshot) -> Result<()> {
+        match snapshot {
+            Snapshot::Build {
+                group,
+                index,
+                notifier,
+            } => {
+                let snapshot = self.handle_build_snapshot(group, index).await?;
+                notifier
+                    .send(snapshot)
+                    .map_err(|_| Error::Other("notify build snapshot error".to_string()))?;
+            }
+            Snapshot::Install {
+                group,
+                index,
+                snapshot,
+                notifier,
+            } => {
+                self.handle_install_snapshot(group, index, snapshot).await?;
+                notifier
+                    .send(())
+                    .map_err(|_| Error::Other("notify install snapshot error".to_string()))?;
+            }
         }
         Ok(())
+    }
+
+    async fn handle_build_snapshot(&mut self, _group: u64, _indexx: u64) -> Result<Vec<u8>> {
+        // TODO: Impl me.
+        Ok(vec![])
+    }
+
+    async fn handle_install_snapshot(
+        &mut self,
+        _group: u64,
+        _index: u64,
+        _snapshot: Vec<u8>,
+    ) -> Result<()> {
+        // TODO: Impl me.
+        Ok(())
+    }
+
+    async fn write_next_apply_index(&self, index: u64) -> Result<()> {
+        let buf = bincode::serialize(&index).map_err(Error::serde_err)?;
+        self.raft_group_log_store
+            .put(DONE_INDEX_KEY.to_vec(), buf)
+            .await?;
+        Ok(())
+    }
+
+    async fn read_next_apply_index(&self) -> Result<Option<u64>> {
+        let raw = self
+            .raft_group_log_store
+            .get(DONE_INDEX_KEY.to_vec())
+            .await?;
+        let index = match raw {
+            Some(raw) => bincode::deserialize(&raw).map_err(Error::serde_err)?,
+            None => None,
+        };
+        Ok(index)
     }
 }

--- a/wheel/src/worker/mod.rs
+++ b/wheel/src/worker/mod.rs
@@ -1,3 +1,4 @@
 pub mod heartbeater;
+#[allow(dead_code)]
 pub mod kv;
 pub mod sstable_uploader;


### PR DESCRIPTION
Separate apply and snapshot cmd channel in `Gear` and `KvWorker`.

Part of work to combine WAL and raft log store.

Ref: #88 .