### PR TITLE
fix: fix raft log block cache indexing

### DIFF
--- a/storage/src/raft_log_store/store.rs
+++ b/storage/src/raft_log_store/store.rs
@@ -329,7 +329,7 @@ impl RaftLogStore {
         let block = self
             .core
             .block_cache
-            .get_or_insert_with(index.file_id, index.offset, read_file)
+            .get_or_insert_with(index.file_id, index.block_offset, read_file)
             .await?;
 
         Ok((&block[index.offset..index.offset + index.len]).to_vec())

--- a/tests/integrations/mod.rs
+++ b/tests/integrations/mod.rs
@@ -86,7 +86,7 @@ async fn test_concurrent_put_get() {
     wheel_client
         .add_endpoints(AddEndpointsRequest {
             endpoints: HashMap::from_iter([(
-                1,
+                wheel_config.id,
                 Endpoint {
                     host: wheel_config.host.to_owned(),
                     port: wheel_config.port as u32,
@@ -104,7 +104,11 @@ async fn test_concurrent_put_get() {
             }),
             group: 1,
             raft_nodes: vec![1, 2, 3],
-            nodes: HashMap::from_iter([(1, 1), (2, 1), (3, 1)]),
+            nodes: HashMap::from_iter([
+                (1, wheel_config.id),
+                (2, wheel_config.id),
+                (3, wheel_config.id),
+            ]),
         }))
         .await
         .unwrap();

--- a/wheel/src/components/network.rs
+++ b/wheel/src/components/network.rs
@@ -45,6 +45,7 @@ pub struct RaftNetworkConnection {
 
 #[async_trait]
 impl openraft::RaftNetwork<RaftTypeConfig> for RaftNetworkConnection {
+    #[tracing::instrument(level = "trace", skip(self))]
     async fn send_append_entries(
         &mut self,
         rpc: openraft::raft::AppendEntriesRequest<RaftTypeConfig>,
@@ -73,6 +74,7 @@ impl openraft::RaftNetwork<RaftTypeConfig> for RaftNetworkConnection {
             .map_err(append_entries_err)?)
     }
 
+    #[tracing::instrument(level = "trace", skip(self))]
     async fn send_install_snapshot(
         &mut self,
         rpc: openraft::raft::InstallSnapshotRequest<RaftTypeConfig>,
@@ -103,6 +105,7 @@ impl openraft::RaftNetwork<RaftTypeConfig> for RaftNetworkConnection {
             .map_err(install_snapshot_err)?)
     }
 
+    #[tracing::instrument(level = "trace", skip(self))]
     async fn send_vote(
         &mut self,
         rpc: openraft::raft::VoteRequest<RaftTypeConfig>,
@@ -155,6 +158,7 @@ impl RaftNetwork {
 impl openraft::RaftNetworkFactory<RaftTypeConfig> for RaftNetwork {
     type Network = RaftNetworkConnection;
 
+    #[tracing::instrument(level = "trace", skip(self))]
     async fn connect(
         &mut self,
         target: <RaftTypeConfig as openraft::RaftTypeConfig>::NodeId,

--- a/wheel/src/components/raft_manager.rs
+++ b/wheel/src/components/raft_manager.rs
@@ -228,7 +228,7 @@ mod tests {
         .unwrap()
         {
             openraft::EntryPayload::Normal(data) => data,
-            _ => unimplemented!(),
+            _ => unreachable!(),
         };
         assert_eq!(txn.to_vec().unwrap(), data);
     }

--- a/wheel/src/lib.rs
+++ b/wheel/src/lib.rs
@@ -16,6 +16,7 @@ use meta::MetaStoreRef;
 use runkv_common::channel_pool::ChannelPool;
 use runkv_common::BoxedWorker;
 use runkv_proto::common::Endpoint as PbEndpoint;
+use runkv_proto::kv::kv_service_server::KvServiceServer;
 use runkv_proto::wheel::raft_service_server::RaftServiceServer;
 use runkv_proto::wheel::wheel_service_server::WheelServiceServer;
 use runkv_storage::components::{BlockCache, SstableStore, SstableStoreOptions, SstableStoreRef};
@@ -45,7 +46,8 @@ pub async fn bootstrap_wheel(
 
     Server::builder()
         .add_service(WheelServiceServer::new(wheel.clone()))
-        .add_service(RaftServiceServer::new(wheel))
+        .add_service(RaftServiceServer::new(wheel.clone()))
+        .add_service(KvServiceServer::new(wheel))
         .serve(addr_str.parse().map_err(Error::err)?)
         .await
         .map_err(Error::err)

--- a/wheel/src/service.rs
+++ b/wheel/src/service.rs
@@ -114,7 +114,10 @@ impl Wheel {
 
     async fn txn_inner(&self, request: TxnRequest) -> Result<TxnResponse> {
         let _buf = request.to_vec().map_err(Error::serde_err)?;
-        todo!()
+        // TODO: Impl me.
+        // TODO: Impl me.
+        // TODO: Impl me.
+        Ok(TxnResponse::default())
     }
 }
 

--- a/wheel/src/worker/mod.rs
+++ b/wheel/src/worker/mod.rs
@@ -1,4 +1,3 @@
 pub mod heartbeater;
-#[allow(dead_code)]
 pub mod kv;
 pub mod sstable_uploader;


### PR DESCRIPTION
As titled. Blocks should be indexed by `block_offset` in raft log store block cache.

(What a miracle it could run before....