### PR TITLE
feat: impl memtable per shard (part 1)

### DIFF
--- a/exhauster/src/compaction_filter.rs
+++ b/exhauster/src/compaction_filter.rs
@@ -2,7 +2,7 @@ use bytes::Bytes;
 
 pub trait CompactionFilter {
     /// Keep the key value pair if `filter` returns true.
-    fn filter(&mut self, key: &[u8], value: Option<&[u8]>, timestamp: u64) -> bool;
+    fn filter(&mut self, key: &[u8], value: Option<&[u8]>, sequence: u64) -> bool;
 }
 
 pub struct DefaultCompactionFilter {
@@ -22,10 +22,10 @@ impl DefaultCompactionFilter {
 }
 
 impl CompactionFilter for DefaultCompactionFilter {
-    fn filter(&mut self, key: &[u8], _value: Option<&[u8]>, timestamp: u64) -> bool {
+    fn filter(&mut self, key: &[u8], _value: Option<&[u8]>, sequence: u64) -> bool {
         let mut retain = true;
         // TODO: Handle `remove_tombstone`.
-        if key == self.last_key && timestamp < self.watermark {
+        if key == self.last_key && sequence < self.watermark {
             retain = false;
         }
         self.last_key = Bytes::copy_from_slice(key);

--- a/exhauster/src/partitioner.rs
+++ b/exhauster/src/partitioner.rs
@@ -2,7 +2,7 @@ use bytes::Bytes;
 
 pub trait Partitioner: Send + Sync + 'static {
     /// Finish building current sstable if returns true.
-    fn partition(&mut self, key: &[u8], value: Option<&[u8]>, timestamp: u64) -> bool;
+    fn partition(&mut self, key: &[u8], value: Option<&[u8]>, sequence: u64) -> bool;
 }
 
 pub type BoxedPartitioner = Box<dyn Partitioner>;
@@ -23,7 +23,7 @@ impl DefaultPartitioner {
 }
 
 impl Partitioner for DefaultPartitioner {
-    fn partition(&mut self, key: &[u8], _value: Option<&[u8]>, _timestamp: u64) -> bool {
+    fn partition(&mut self, key: &[u8], _value: Option<&[u8]>, _sequence: u64) -> bool {
         if self.offset >= self.partition_points.len() {
             return false;
         }
@@ -39,7 +39,7 @@ impl Partitioner for DefaultPartitioner {
 pub struct NoPartitioner;
 
 impl Partitioner for NoPartitioner {
-    fn partition(&mut self, _key: &[u8], _value: Option<&[u8]>, _timestamp: u64) -> bool {
+    fn partition(&mut self, _key: &[u8], _value: Option<&[u8]>, _sequence: u64) -> bool {
         false
     }
 }

--- a/exhauster/src/service.rs
+++ b/exhauster/src/service.rs
@@ -12,7 +12,7 @@ use runkv_storage::components::{
     CachePolicy, Sstable, SstableBuilder, SstableBuilderOptions, SstableStoreRef,
 };
 use runkv_storage::iterator::{BoxedIterator, Iterator, MergeIterator, Seek, SstableIterator};
-use runkv_storage::utils::{timestamp, user_key, value};
+use runkv_storage::utils::{sequence, user_key, value};
 use tonic::{Request, Response, Status};
 use tracing::{debug, trace};
 
@@ -97,7 +97,7 @@ impl ExhausterService for Exhauster {
         // Filter key value pairs.
         while iter.is_valid() {
             let uk = user_key(iter.key());
-            let ts = timestamp(iter.key());
+            let ts = sequence(iter.key());
             let v = value(iter.value());
 
             if sstable_builder.is_none() {

--- a/rudder/src/service.rs
+++ b/rudder/src/service.rs
@@ -30,7 +30,7 @@ pub struct Rudder {
     /// Manifest of sstables.
     version_manager: VersionManager,
     channel_pool: ChannelPool,
-    /// The smallest pinned timestamp. Any data whose timestamp is smaller than `watermark` can be
+    /// The smallest pinned sequence. Any data whose sequence is smaller than `watermark` can be
     /// safely delete.
     ///
     /// `wheel node` maintains its own watermark, and `rudder node` collects watermarks from each

--- a/storage/src/lsm_tree/components/sstable.rs
+++ b/storage/src/lsm_tree/components/sstable.rs
@@ -277,7 +277,7 @@ impl SstableBuilder {
     }
 
     /// Add kv pair to sstable.
-    pub fn add(&mut self, user_key: &[u8], timestamp: u64, value: Option<&[u8]>) -> Result<()> {
+    pub fn add(&mut self, user_key: &[u8], sequence: u64, value: Option<&[u8]>) -> Result<()> {
         // Rotate block builder if the previous one has been built.
         if self.block_builder.is_none() {
             self.block_builder = Some(BlockBuilder::new(BlockBuilderOptions {
@@ -294,7 +294,7 @@ impl SstableBuilder {
         }
 
         let block_builder = self.block_builder.as_mut().unwrap();
-        let full_key = full_key(user_key, timestamp);
+        let full_key = full_key(user_key, sequence);
 
         block_builder.add(&full_key, &raw_value(value));
 

--- a/storage/src/lsm_tree/manifest/version.rs
+++ b/storage/src/lsm_tree/manifest/version.rs
@@ -45,7 +45,7 @@ pub struct VersionManagerCore {
     diffs: VecDeque<VersionDiff>,
     /// `sstable_store` is used to fetch sstable meta.
     sstable_store: SstableStoreRef,
-    /// Minimum accessable timestamp.
+    /// Minimum accessable sequence.
     watermark: u64,
 }
 
@@ -856,12 +856,12 @@ mod tests {
         sstable_store: SstableStoreRef,
         sst_id: u64,
         kvs: &[(&'static [u8], &'static [u8])],
-        timestamp: u64,
+        sequence: u64,
     ) {
         let options = SstableBuilderOptions::default();
         let mut builder = SstableBuilder::new(options);
         for (k, v) in kvs {
-            builder.add(k, timestamp, Some(v)).unwrap();
+            builder.add(k, sequence, Some(v)).unwrap();
         }
         let (meta, data) = builder.build().unwrap();
         let sst = Sstable::new(sst_id, Arc::new(meta));

--- a/storage/src/utils/coding.rs
+++ b/storage/src/utils/coding.rs
@@ -145,14 +145,14 @@ pub fn crc32check(data: &[u8], crc32sum: u32) -> bool {
 /// A full key value pair looks like:
 ///
 /// ```plain
-/// | user key | timestamp (8B) | value |
+/// | user key | sequence (8B) | value |
 ///
 /// |<------- full key ------->|
 /// ```
-pub fn full_key(user_key: &[u8], timestamp: u64) -> Vec<u8> {
+pub fn full_key(user_key: &[u8], sequence: u64) -> Vec<u8> {
     let mut buf = Vec::with_capacity(user_key.len() + 8);
     buf.put_slice(user_key);
-    buf.put_u64(!timestamp);
+    buf.put_u64(!sequence);
     buf
 }
 
@@ -161,8 +161,8 @@ pub fn user_key(full_key: &[u8]) -> &[u8] {
     &full_key[..full_key.len() - 8]
 }
 
-/// Get timestamp in full key.
-pub fn timestamp(full_key: &[u8]) -> u64 {
+/// Get sequence in full key.
+pub fn sequence(full_key: &[u8]) -> u64 {
     !(&full_key[full_key.len() - 8..]).get_u64()
 }
 

--- a/wheel/src/main.rs
+++ b/wheel/src/main.rs
@@ -26,6 +26,6 @@ async fn main() -> Result<()> {
             .map_err(Error::config_err)?;
     info!("config: {:?}", config);
 
-    let (wheel, _lsm_tree, workers) = build_wheel(&config).await?;
+    let (wheel, workers) = build_wheel(&config).await?;
     bootstrap_wheel(&config, wheel, workers).await
 }

--- a/wheel/src/service.rs
+++ b/wheel/src/service.rs
@@ -27,7 +27,6 @@ use tracing::trace;
 
 use crate::components::command::Command;
 use crate::components::gear::Gear;
-use crate::components::lsm_tree::ObjectStoreLsmTree;
 use crate::components::network::RaftNetwork;
 use crate::components::raft_manager::RaftManager;
 use crate::components::Raft;
@@ -39,7 +38,6 @@ fn internal(e: impl Into<Box<dyn std::error::Error>>) -> Status {
 }
 
 pub struct WheelOptions {
-    pub lsm_tree: ObjectStoreLsmTree,
     pub meta_store: MetaStoreRef,
     pub channel_pool: ChannelPool,
     pub raft_log_store: RaftLogStore,
@@ -49,7 +47,6 @@ pub struct WheelOptions {
 }
 
 struct WheelInner {
-    _lsm_tree: ObjectStoreLsmTree,
     meta_store: MetaStoreRef,
     channel_pool: ChannelPool,
     _raft_log_store: RaftLogStore,
@@ -68,7 +65,6 @@ impl Wheel {
     pub fn new(options: WheelOptions) -> Self {
         Self {
             inner: Arc::new(WheelInner {
-                _lsm_tree: options.lsm_tree,
                 meta_store: options.meta_store,
                 channel_pool: options.channel_pool,
                 _raft_log_store: options.raft_log_store,


### PR DESCRIPTION
Separate shared memtable, make each shard writes its own memtable.

State:

Temporarily disable integration tests. Restore it after sequence is refactored and kv client can be used.