### PR TITLE
feat: use tracing feature to reduce operations for tracing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2174,6 +2174,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "bincode",
  "bytes",
  "bytesize",
  "chrono",
@@ -2233,10 +2234,10 @@ name = "runkv-proto"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "bincode",
  "bytes",
  "prost",
  "prost-build",
+ "runkv-common",
  "serde",
  "serde_derive",
  "tonic",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2001,6 +2001,7 @@ dependencies = [
 [[package]]
 name = "raft"
 version = "0.7.0"
+source = "git+https://github.com/mrcroxx/raft-rs?rev=f44c57464e9939c66f5e1bcb6913e9be28213689#f44c57464e9939c66f5e1bcb6913e9be28213689"
 dependencies = [
  "async-recursion",
  "async-trait",
@@ -2019,12 +2020,12 @@ dependencies = [
  "slog-term",
  "thiserror",
  "tokio",
- "tracing",
 ]
 
 [[package]]
 name = "raft-proto"
 version = "0.7.0"
+source = "git+https://github.com/mrcroxx/raft-rs?rev=f44c57464e9939c66f5e1bcb6913e9be28213689#f44c57464e9939c66f5e1bcb6913e9be28213689"
 dependencies = [
  "lazy_static",
  "prost",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2001,7 +2001,6 @@ dependencies = [
 [[package]]
 name = "raft"
 version = "0.7.0"
-source = "git+https://github.com/mrcroxx/raft-rs?rev=f44c57464e9939c66f5e1bcb6913e9be28213689#f44c57464e9939c66f5e1bcb6913e9be28213689"
 dependencies = [
  "async-recursion",
  "async-trait",
@@ -2020,12 +2019,12 @@ dependencies = [
  "slog-term",
  "thiserror",
  "tokio",
+ "tracing",
 ]
 
 [[package]]
 name = "raft-proto"
 version = "0.7.0"
-source = "git+https://github.com/mrcroxx/raft-rs?rev=f44c57464e9939c66f5e1bcb6913e9be28213689#f44c57464e9939c66f5e1bcb6913e9be28213689"
 dependencies = [
  "lazy_static",
  "prost",

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 [dependencies]
 anyhow = "1.0"
 async-trait = "0.1"
+bincode = "1.3.3"
 bytes = "1"
 bytesize = { version = "1.1.0", features = ["serde"] }
 chrono = "0.4"

--- a/common/src/coding.rs
+++ b/common/src/coding.rs
@@ -1,6 +1,16 @@
 use bytes::{Buf, BufMut};
 use serde::Deserialize;
 
+pub trait BytesSerde<'de>: serde::Serialize + serde::Deserialize<'de> + Sized {
+    fn encode_to_vec(&self) -> anyhow::Result<Vec<u8>> {
+        bincode::serialize(self).map_err(|e| anyhow::anyhow!("bincode serialize error: {}", e))
+    }
+
+    fn decode(slice: &'de [u8]) -> anyhow::Result<Self> {
+        bincode::deserialize(slice).map_err(|e| anyhow::anyhow!("bincode deserialize error: {}", e))
+    }
+}
+
 #[derive(Deserialize, Clone, Copy, Debug)]
 pub enum CompressionAlgorithm {
     None,

--- a/common/src/context.rs
+++ b/common/src/context.rs
@@ -1,0 +1,8 @@
+use crate::coding::BytesSerde;
+
+#[derive(serde::Serialize, serde::Deserialize, Clone, Debug)]
+pub struct Context {
+    pub id: u64,
+}
+
+impl<'de> BytesSerde<'de> for Context {}

--- a/common/src/context.rs
+++ b/common/src/context.rs
@@ -2,7 +2,8 @@ use crate::coding::BytesSerde;
 
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug)]
 pub struct Context {
-    pub id: u64,
+    pub span_id: u64,
+    pub request_id: u64,
 }
 
 impl<'de> BytesSerde<'de> for Context {}

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -2,6 +2,7 @@ pub mod atomic;
 pub mod channel_pool;
 pub mod coding;
 pub mod config;
+pub mod context;
 pub mod log;
 pub mod notify_pool;
 pub mod time;

--- a/common/src/log.rs
+++ b/common/src/log.rs
@@ -25,10 +25,11 @@ pub fn init_runkv_logger(service_name: &str) {
         // Configure RunKV's own crates to log at TRACE level, and ignore all third-party crates.
         let filter = tracing_subscriber::filter::Targets::new()
             // Enable trace for most modules.
+            .with_target("runkv_common", tracing::Level::TRACE)
+            .with_target("runkv_storage", tracing::Level::TRACE)
             .with_target("runkv_rudder", tracing::Level::TRACE)
             .with_target("runkv_wheel", tracing::Level::TRACE)
             .with_target("runkv_exhauster", tracing::Level::TRACE)
-            .with_target("runkv_storage", tracing::Level::TRACE)
             .with_target("runkv_tests", tracing::Level::TRACE)
             .with_target("openraft::raft", tracing::Level::TRACE)
             .with_target("raft", tracing::Level::TRACE)
@@ -41,5 +42,16 @@ pub fn init_runkv_logger(service_name: &str) {
         tracing_subscriber::registry()
             .with(opentelemetry_layer)
             .init();
+    }
+}
+
+pub fn shutdown_runkv_logger() {
+    let enable_jaeger_tracing = match std::env::var("RUNKV_TRACE") {
+        Err(_) => false,
+        Ok(val) => val.parse().unwrap(),
+    };
+
+    if enable_jaeger_tracing {
+        opentelemetry::global::shutdown_tracer_provider();
     }
 }

--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -6,9 +6,9 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0"
-bincode = "1.3.3"
 bytes = "1"
 prost = "0.9"
+runkv-common = { path = "../common" }
 serde = "1.0"
 serde_derive = "1.0"
 tonic = "0.6.2"

--- a/proto/src/lib.rs
+++ b/proto/src/lib.rs
@@ -46,16 +46,7 @@ pub mod kv {
     #![allow(clippy::all)]
     tonic::include_proto!("kv");
 
-    pub trait BytesSerde<'de>: serde::Serialize + serde::Deserialize<'de> + Sized {
-        fn encode_to_vec(&self) -> anyhow::Result<Vec<u8>> {
-            bincode::serialize(self).map_err(|e| anyhow::anyhow!("bincode serialize error: {}", e))
-        }
-
-        fn decode(slice: &'de [u8]) -> anyhow::Result<Self> {
-            bincode::deserialize(slice)
-                .map_err(|e| anyhow::anyhow!("bincode deserialize error: {}", e))
-        }
-    }
+    use runkv_common::coding::BytesSerde;
 
     impl<'de> BytesSerde<'de> for TxnRequest {}
     impl<'de> BytesSerde<'de> for TxnResponse {}

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -33,3 +33,6 @@ tokio = { version = "1", features = [
 toml = "0.4.2"
 tonic = "0.6.2"
 tracing = "0.1"
+
+[features]
+tracing = ["runkv-wheel/tracing"]

--- a/wheel/Cargo.toml
+++ b/wheel/Cargo.toml
@@ -23,9 +23,9 @@ moka = { version = "0.7", features = ["future"] }
 parking_lot = "0.12"
 prometheus = "0.13.0"
 prost = "0.9"
-raft = { git = "https://github.com/mrcroxx/raft-rs", rev = "f44c57464e9939c66f5e1bcb6913e9be28213689" }
+# raft = { git = "https://github.com/mrcroxx/raft-rs", rev = "f44c57464e9939c66f5e1bcb6913e9be28213689" }
 # Uncomment this line if you want to debug raft-rs locally.
-# raft = { path = "../../raft-rs" }
+raft = { path = "../../raft-rs" }
 rand = "0.8.5"
 runkv-common = { path = "../common" }
 runkv-proto = { path = "../proto" }
@@ -50,3 +50,6 @@ tracing-subscriber = "0.3"
 assert_matches = "1.5.0"
 env_logger = "*"
 test-log = "0.2.10"
+
+[features]
+tracing = []

--- a/wheel/Cargo.toml
+++ b/wheel/Cargo.toml
@@ -23,9 +23,9 @@ moka = { version = "0.7", features = ["future"] }
 parking_lot = "0.12"
 prometheus = "0.13.0"
 prost = "0.9"
-# raft = { git = "https://github.com/mrcroxx/raft-rs", rev = "f44c57464e9939c66f5e1bcb6913e9be28213689" }
+raft = { git = "https://github.com/mrcroxx/raft-rs", rev = "f44c57464e9939c66f5e1bcb6913e9be28213689" }
 # Uncomment this line if you want to debug raft-rs locally.
-raft = { path = "../../raft-rs" }
+# raft = { path = "../../raft-rs" }
 rand = "0.8.5"
 runkv-common = { path = "../common" }
 runkv-proto = { path = "../proto" }

--- a/wheel/src/components/command.rs
+++ b/wheel/src/components/command.rs
@@ -1,6 +1,7 @@
 use std::ops::Range;
 
-use runkv_proto::kv::{BytesSerde, TxnRequest};
+use runkv_common::coding::BytesSerde;
+use runkv_proto::kv::TxnRequest;
 use serde::{Deserialize, Serialize};
 use tokio::sync::oneshot;
 

--- a/wheel/src/components/raft_log_store.rs
+++ b/wheel/src/components/raft_log_store.rs
@@ -205,7 +205,7 @@ impl raft::Storage for RaftGroupLogStore {
     /// [first_index()-1, last_index()]. The term of the entry before
     /// first_index is retained for matching purpose even though the
     /// rest of that entry may not be available.
-    #[tracing::instrument(level = "trace")]
+    #[tracing::instrument(level = "trace", ret, err)]
     async fn term(&self, idx: u64) -> raft::Result<u64> {
         let may_term = self.core.term(self.group, idx).await.map_err(err)?;
         if let Some(term) = may_term {

--- a/wheel/src/lib.rs
+++ b/wheel/src/lib.rs
@@ -1,3 +1,5 @@
+#![feature(let_chains)]
+
 pub mod components;
 pub mod config;
 pub mod error;

--- a/wheel/src/service.rs
+++ b/wheel/src/service.rs
@@ -5,14 +5,15 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use itertools::Itertools;
 use runkv_common::channel_pool::ChannelPool;
+use runkv_common::coding::BytesSerde;
 use runkv_common::config::Node;
 use runkv_common::notify_pool::NotifyPool;
 use runkv_proto::common::Endpoint;
 use runkv_proto::kv::kv_service_server::KvService;
 use runkv_proto::kv::{
-    kv_op_request, kv_op_response, BytesSerde, DeleteRequest, DeleteResponse, GetRequest,
-    GetResponse, KvOpRequest, PutRequest, PutResponse, SnapshotRequest, SnapshotResponse,
-    TxnRequest, TxnResponse,
+    kv_op_request, kv_op_response, DeleteRequest, DeleteResponse, GetRequest, GetResponse,
+    KvOpRequest, PutRequest, PutResponse, SnapshotRequest, SnapshotResponse, TxnRequest,
+    TxnResponse,
 };
 use runkv_proto::wheel::raft_service_server::RaftService;
 use runkv_proto::wheel::wheel_service_server::WheelService;

--- a/wheel/src/worker/raft.rs
+++ b/wheel/src/worker/raft.rs
@@ -1,11 +1,12 @@
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use async_trait::async_trait;
+use runkv_common::context::Context;
 use runkv_common::Worker;
 use runkv_storage::raft_log_store::entry::RaftLogBatchBuilder;
 use serde::{Deserialize, Serialize};
 use tokio::sync::mpsc;
-use tracing::{trace, warn};
+use tracing::{trace, trace_span, warn};
 
 use crate::components::fsm::Fsm;
 use crate::components::raft_log_store::{encode_entry_data, RaftGroupLogStore};
@@ -91,8 +92,8 @@ impl<RN: RaftNetwork, F: Fsm> RaftWorker<RN, F> {
             // election_tick: todo!(),
             // heartbeat_tick: todo!(),
             applied,
-            // max_size_per_msg: todo!(),
-            // max_inflight_msgs: todo!(),
+            max_size_per_msg: 1 << 20,
+            max_inflight_msgs: 256,
             check_quorum: true,
             pre_vote: true,
             // min_election_tick: todo!(),
@@ -143,29 +144,81 @@ impl<RN: RaftNetwork, F: Fsm> RaftWorker<RN, F> {
     }
 
     async fn run_inner(&mut self) -> Result<()> {
-        // [`Interval`] with default [`MissedTickBehavior::Brust`].
-        let mut ticker = tokio::time::interval(RAFT_HEARTBEAT_TICK_DURATION);
+        // // [`Interval`] with default [`MissedTickBehavior::Brust`].
+        // let mut ticker = tokio::time::interval(RAFT_HEARTBEAT_TICK_DURATION);
 
+        // loop {
+        //     tokio::select! {
+        //         biased;
+
+        //         _ = ticker.tick() => {
+        //             self.tick().await;
+        //         }
+
+        //         true = self.raft.has_ready() => {
+        //             self.handle_ready().await?;
+
+        //         }
+
+        //         Some(msg) = self.message_rx.recv() => {
+        //             self.step(msg).await?;
+        //         }
+
+        //         Some(proposal) = self.proposal_rx.recv() => {
+        //             self.propose(proposal).await?;
+        //         }
+
+        //     }
+        // }
+
+        const MIN_LOOP_DURATION: Duration = Duration::from_millis(1);
+        let mut remaining_timeout = RAFT_HEARTBEAT_TICK_DURATION;
         loop {
-            tokio::select! {
-                biased;
+            let now = Instant::now();
 
-                _ = ticker.tick() => {
-                    self.tick().await;
+            const BATCH_SIZE: usize = 128;
+            let mut msgs = Vec::with_capacity(BATCH_SIZE);
+            let mut proposals = Vec::with_capacity(BATCH_SIZE);
+
+            let recv_span = trace_span!("recv_span");
+            let recv_span_guard = recv_span.enter();
+            for _ in 0..BATCH_SIZE {
+                match self.message_rx.try_recv() {
+                    Ok(msg) => msgs.push(msg),
+                    Err(mpsc::error::TryRecvError::Empty) => {}
+                    Err(e) => return Err(Error::err(e)),
                 }
 
-                Some(msg) = self.message_rx.recv() => {
-                    self.step(msg).await?;
+                match self.proposal_rx.try_recv() {
+                    Ok(proposal) => proposals.push(proposal),
+                    Err(mpsc::error::TryRecvError::Empty) => {}
+                    Err(e) => return Err(Error::err(e)),
                 }
+            }
+            drop(recv_span_guard);
 
-                Some(proposal) = self.proposal_rx.recv() => {
-                    self.propose(proposal).await?;
-                }
+            for proposal in proposals {
+                self.propose(proposal).await?;
+            }
 
-                true = self.raft.has_ready() => {
-                    self.handle_ready().await?;
-                }
+            for msg in msgs {
+                self.step(msg).await?;
+            }
 
+            if self.raft.has_ready().await {
+                self.handle_ready().await?;
+            }
+
+            let mut elapsed = now.elapsed();
+            if elapsed < MIN_LOOP_DURATION {
+                tokio::time::sleep(MIN_LOOP_DURATION - elapsed).await;
+                elapsed = now.elapsed();
+            }
+            if elapsed >= remaining_timeout {
+                remaining_timeout = RAFT_HEARTBEAT_TICK_DURATION;
+                self.tick().await;
+            } else {
+                remaining_timeout -= elapsed;
             }
         }
     }
@@ -175,8 +228,14 @@ impl<RN: RaftNetwork, F: Fsm> RaftWorker<RN, F> {
         self.raft.tick().await;
     }
 
-    #[tracing::instrument(level = "trace")]
+    #[tracing::instrument(level = "trace", fields(request_id))]
     async fn propose(&mut self, proposal: Proposal) -> Result<()> {
+        if cfg!(feature = "tracing") {
+            let span = tracing::Span::current();
+            let ctx: Context = bincode::deserialize(&proposal.context).map_err(Error::serde_err)?;
+            span.follows_from(tracing::Id::from_u64(ctx.span_id));
+            span.record("request_id", &ctx.request_id);
+        }
         self.raft
             .propose(proposal.context, proposal.data)
             .await
@@ -238,6 +297,22 @@ impl<RN: RaftNetwork, F: Fsm> RaftWorker<RN, F> {
 
     #[tracing::instrument(level = "trace")]
     async fn send_messages(&mut self, messages: Vec<raft::prelude::Message>) -> Result<()> {
+        if cfg!(feature = "tracing") {
+            let span = tracing::Span::current();
+            for msg in messages.iter() {
+                if msg.msg_type() == raft::prelude::MessageType::MsgAppend {
+                    for entry in msg.entries.iter() {
+                        if entry.entry_type() == raft::prelude::EntryType::EntryNormal
+                            && !entry.data.is_empty()
+                        {
+                            let ctx: Context =
+                                bincode::deserialize(&entry.context).map_err(Error::serde_err)?;
+                            span.follows_from(tracing::Id::from_u64(ctx.span_id));
+                        }
+                    }
+                }
+            }
+        }
         self.raft_network.send(messages).await
     }
 
@@ -263,6 +338,12 @@ impl<RN: RaftNetwork, F: Fsm> RaftWorker<RN, F> {
     async fn append_log_entries(&mut self, entries: Vec<raft::prelude::Entry>) -> Result<()> {
         let mut builder = RaftLogBatchBuilder::default();
         for entry in entries {
+            if cfg!(feature = "tracing") && let raft::prelude::EntryType::EntryNormal = entry.entry_type() && !entry.data.is_empty() {
+                let span = tracing::Span::current();
+                let ctx: Context = bincode::deserialize(&entry.context).map_err(Error::serde_err)?;
+                span.follows_from(tracing::Id::from_u64(ctx.span_id));
+            }
+
             let data = encode_entry_data(&entry);
             builder.add(
                 self.raft_node,
@@ -341,7 +422,7 @@ mod tests {
         let (_proposal_tx_2, mut apply_rx_2) = worker!(2);
         let (_proposal_tx_3, mut apply_rx_3) = worker!(3);
 
-        tokio::time::sleep(Duration::from_secs(3)).await;
+        tokio::time::sleep(Duration::from_secs(10)).await;
 
         let data = vec![b'd'; 16];
         let context = vec![b'c'; 16];


### PR DESCRIPTION
As titled.

Now, operations for tracing (e.g. configuring `follows_form` for spans) are only enabled when building with feature `tracing`.

And opentelemetry subscriber is only enabled with env `RUNKV_TRACE=true`.

So, if you want to do tracing, run commands like this:
`./run k && ./run d && RUNKV_TRACE=true RUST_BACKTRACE=1 cargo test --features tracing --package runkv_tests --test integrations -- test_concurrent_put_get --exact --nocapture`