### PR TITLE
feat: using client-side streaming and avoiding read lock to optimize raft message sending

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2171,6 +2171,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "runkv-client"
+version = "0.1.0"
+dependencies = [
+ "runkv-common",
+ "runkv-proto",
+ "tonic",
+]
+
+[[package]]
 name = "runkv-common"
 version = "0.1.0"
 dependencies = [
@@ -2320,6 +2329,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "runkv-tests"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "bytes",
+ "bytesize",
+ "env_logger",
+ "futures",
+ "itertools",
+ "lazy_static",
+ "rand",
+ "runkv-common",
+ "runkv-exhauster",
+ "runkv-proto",
+ "runkv-rudder",
+ "runkv-storage",
+ "runkv-wheel",
+ "tempfile",
+ "test-log",
+ "tokio",
+ "toml",
+ "tonic",
+ "tracing",
+]
+
+[[package]]
 name = "runkv-wheel"
 version = "0.1.0"
 dependencies = [
@@ -2333,6 +2368,7 @@ dependencies = [
  "clap 3.1.6",
  "env_logger",
  "futures",
+ "futures-util",
  "http",
  "humantime",
  "humantime-serde",
@@ -2359,32 +2395,6 @@ dependencies = [
  "tonic",
  "tracing",
  "tracing-subscriber",
-]
-
-[[package]]
-name = "runkv_tests"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "bytes",
- "bytesize",
- "env_logger",
- "futures",
- "itertools",
- "lazy_static",
- "rand",
- "runkv-common",
- "runkv-exhauster",
- "runkv-proto",
- "runkv-rudder",
- "runkv-storage",
- "runkv-wheel",
- "tempfile",
- "test-log",
- "tokio",
- "toml",
- "tonic",
- "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = [
+    "client",
     "common",
     "exhauster",
     "proto",

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "runkv-client"
+version = "0.1.0"
+edition = "2021"
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+runkv-common = { path = "../common" }
+runkv-proto = { path = "../proto" }
+tonic = "0.6.2"

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -1,0 +1,9 @@
+#![allow(dead_code)]
+
+use runkv_proto::kv::kv_service_client::KvServiceClient;
+use tonic::transport::Channel;
+
+#[derive(Clone)]
+pub struct RunKVClient {
+    client: KvServiceClient<Channel>,
+}

--- a/etc/grafana-dashboards/runkv-overview.json
+++ b/etc/grafana-dashboards/runkv-overview.json
@@ -766,13 +766,14 @@
         "type": "prometheus",
         "uid": "PEDE6B306CC9C0CD0"
       },
+      "description": "",
       "fieldConfig": {
         "defaults": {
           "color": {
             "mode": "palette-classic"
           },
           "custom": {
-            "axisLabel": "Bandwidth",
+            "axisLabel": "Latency",
             "axisPlacement": "auto",
             "barAlignment": 0,
             "drawStyle": "line",
@@ -813,7 +814,7 @@
               }
             ]
           },
-          "unit": "binBps"
+          "unit": "s"
         },
         "overrides": []
       },
@@ -823,7 +824,7 @@
         "x": 12,
         "y": 26
       },
-      "id": 16,
+      "id": 14,
       "options": {
         "legend": {
           "calcs": [],
@@ -842,14 +843,41 @@
             "uid": "PEDE6B306CC9C0CD0"
           },
           "editorMode": "code",
-          "expr": "irate(raft_append_log_entries_bytes_gauge_vec[1m])",
+          "exemplar": false,
+          "expr": "avg(histogram_quantile(0.5, irate(raft_send_messages_latency_histogram_vec_bucket[1m]))) by (instance)",
+          "format": "time_series",
+          "instant": false,
+          "interval": "",
+          "legendFormat": "p50-{{instance}}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PEDE6B306CC9C0CD0"
+          },
+          "editorMode": "code",
+          "expr": "avg(histogram_quantile(0.9, irate(raft_send_messages_latency_histogram_vec_bucket[1m]))) by (instance)",
           "hide": false,
-          "legendFormat": "bandwitdh-{{instance}}",
+          "legendFormat": "p90-{{instance}}",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PEDE6B306CC9C0CD0"
+          },
+          "editorMode": "code",
+          "expr": "avg(histogram_quantile(0.99, irate(raft_send_messages_latency_histogram_vec_bucket[1m]))) by (instance)",
+          "hide": false,
+          "legendFormat": "p99-{{instance}}",
           "range": true,
           "refId": "C"
         }
       ],
-      "title": "Append Log Entries - Instance Bytes",
+      "title": "Send Messages - Instance Latency",
       "type": "timeseries"
     },
     {
@@ -954,7 +982,7 @@
             "mode": "palette-classic"
           },
           "custom": {
-            "axisLabel": "Latency",
+            "axisLabel": "Bandwidth",
             "axisPlacement": "auto",
             "barAlignment": 0,
             "drawStyle": "line",
@@ -995,7 +1023,7 @@
               }
             ]
           },
-          "unit": "s"
+          "unit": "ops"
         },
         "overrides": []
       },
@@ -1005,7 +1033,7 @@
         "x": 12,
         "y": 34
       },
-      "id": 15,
+      "id": 18,
       "options": {
         "legend": {
           "calcs": [],
@@ -1024,41 +1052,14 @@
             "uid": "PEDE6B306CC9C0CD0"
           },
           "editorMode": "code",
-          "exemplar": false,
-          "expr": "avg(histogram_quantile(0.5, irate(raft_apply_log_entries_latency_histogram_vec_bucket[1m]))) by (instance)",
-          "format": "time_series",
-          "instant": false,
-          "interval": "",
-          "legendFormat": "p50-{{instance}}",
-          "range": true,
-          "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PEDE6B306CC9C0CD0"
-          },
-          "editorMode": "code",
-          "expr": "avg(histogram_quantile(0.9, irate(raft_apply_log_entries_latency_histogram_vec_bucket[1m]))) by (instance)",
+          "expr": "irate(raft_send_messages_latency_histogram_vec_count[1m])",
           "hide": false,
-          "legendFormat": "p90-{{instance}}",
-          "range": true,
-          "refId": "B"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PEDE6B306CC9C0CD0"
-          },
-          "editorMode": "code",
-          "expr": "avg(histogram_quantile(0.99, irate(raft_apply_log_entries_latency_histogram_vec_bucket[1m]))) by (instance)",
-          "hide": false,
-          "legendFormat": "p99-{{instance}}",
+          "legendFormat": "bandwitdh-{{instance}}",
           "range": true,
           "refId": "C"
         }
       ],
-      "title": "Apply Log Entries - Instance Latency",
+      "title": "Send Messages - Instance Frequency",
       "type": "timeseries"
     },
     {
@@ -1066,7 +1067,188 @@
         "type": "prometheus",
         "uid": "PEDE6B306CC9C0CD0"
       },
-      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "Bandwidth",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "binBps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 42
+      },
+      "id": 16,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PEDE6B306CC9C0CD0"
+          },
+          "editorMode": "code",
+          "expr": "irate(raft_append_log_entries_bytes_gauge_vec[1m])",
+          "hide": false,
+          "legendFormat": "bandwitdh-{{instance}}",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Append Log Entries - Instance Bytes",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PEDE6B306CC9C0CD0"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "Bandwidth",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "binBps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 42
+      },
+      "id": 19,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PEDE6B306CC9C0CD0"
+          },
+          "editorMode": "code",
+          "expr": "irate(raft_send_messages_bytes_gauge_vec[1m])",
+          "hide": false,
+          "legendFormat": "bandwitdh-{{instance}}",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Send Messages - Instance Bytes",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PEDE6B306CC9C0CD0"
+      },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1122,9 +1304,9 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 42
+        "y": 50
       },
-      "id": 14,
+      "id": 15,
       "options": {
         "legend": {
           "calcs": [],
@@ -1144,7 +1326,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "avg(histogram_quantile(0.5, irate(raft_send_messages_latency_histogram_vec_bucket[1m]))) by (instance)",
+          "expr": "avg(histogram_quantile(0.5, irate(raft_apply_log_entries_latency_histogram_vec_bucket[1m]))) by (instance)",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -1158,7 +1340,7 @@
             "uid": "PEDE6B306CC9C0CD0"
           },
           "editorMode": "code",
-          "expr": "avg(histogram_quantile(0.9, irate(raft_send_messages_latency_histogram_vec_bucket[1m]))) by (instance)",
+          "expr": "avg(histogram_quantile(0.9, irate(raft_apply_log_entries_latency_histogram_vec_bucket[1m]))) by (instance)",
           "hide": false,
           "legendFormat": "p90-{{instance}}",
           "range": true,
@@ -1170,14 +1352,14 @@
             "uid": "PEDE6B306CC9C0CD0"
           },
           "editorMode": "code",
-          "expr": "avg(histogram_quantile(0.99, irate(raft_send_messages_latency_histogram_vec_bucket[1m]))) by (instance)",
+          "expr": "avg(histogram_quantile(0.99, irate(raft_apply_log_entries_latency_histogram_vec_bucket[1m]))) by (instance)",
           "hide": false,
           "legendFormat": "p99-{{instance}}",
           "range": true,
           "refId": "C"
         }
       ],
-      "title": "Send Messages - Instance Latency",
+      "title": "Apply Log Entries - Instance Latency",
       "type": "timeseries"
     }
   ],

--- a/proto/src/proto/wheel.proto
+++ b/proto/src/proto/wheel.proto
@@ -23,50 +23,12 @@ message AddKeyRangeRequest {
 
 message AddKeyRangeResponse {}
 
-message InitializeRaftGroupRequest {
-  uint64 leader = 1;
-  repeated uint64 raft_nodes = 2;
-}
-
-message InitializeRaftGroupResponse {}
-
 service WheelService {
   rpc AddKeyRange(AddKeyRangeRequest) returns (AddKeyRangeResponse);
   rpc AddEndpoints(AddEndpointsRequest) returns (AddEndpointsResponse);
-  rpc InitializeRaftGroup(InitializeRaftGroupRequest) returns (InitializeRaftGroupResponse);
 }
 
 // ***** raft service *****
-
-message AppendEntriesRequest {
-  uint64 id = 1;
-  bytes data = 2;
-}
-
-message AppendEntriesResponse {
-  uint64 id = 1;
-  bytes data = 2;
-}
-
-message InstallSnapshotRequest {
-  uint64 id = 1;
-  bytes data = 2;
-}
-
-message InstallSnapshotResponse {
-  uint64 id = 1;
-  bytes data = 2;
-}
-
-message VoteRequest {
-  uint64 id = 1;
-  bytes data = 2;
-}
-
-message VoteResponse {
-  uint64 id = 1;
-  bytes data = 2;
-}
 
 message RaftRequest {
   bytes data = 1;
@@ -75,8 +37,5 @@ message RaftRequest {
 message RaftResponse {}
 
 service RaftService {
-  rpc AppendEntries(AppendEntriesRequest) returns (AppendEntriesResponse);
-  rpc InstallSnapshot(InstallSnapshotRequest) returns (InstallSnapshotResponse);
-  rpc Vote(VoteRequest) returns (VoteResponse);
-  rpc Raft(RaftRequest) returns (RaftResponse);
+  rpc Raft(stream RaftRequest) returns (RaftResponse);
 }

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "runkv_tests"
+name = "runkv-tests"
 version = "0.1.0"
 edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/wheel/Cargo.toml
+++ b/wheel/Cargo.toml
@@ -13,6 +13,7 @@ bytesize = { version = "1.1.0", features = ["serde"] }
 chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "3.1.6", features = ["derive"] }
 futures = "0.3"
+futures-util = "0.3"
 http = "0.2.6"
 humantime = "2.1.0"
 humantime-serde = "1.1.1"


### PR DESCRIPTION
Changes:
- Use client-side streaming grpc to reduce raft send messages latency.
- Raft worker get raft clients when init to avoid read lock when sending raft messages.

Summary:
- Raft send messages latency gains barely nothing from client-side streaming grpc or avoiding read lock (Maybe the messages batch is small? Need metrics to further investigate).
- Avoiding read lock benefits the serivce latency.

Ref: #126 .