### PR TITLE
fix: do fsync

### DIFF
--- a/storage/bench/bench_raft_log_store.rs
+++ b/storage/bench/bench_raft_log_store.rs
@@ -23,7 +23,7 @@ struct Args {
 
     #[clap(long, default_value = "100")]
     groups: usize,
-    #[clap(long, default_value = "100000")]
+    #[clap(long, default_value = "10000")]
     entries: usize,
     #[clap(long, default_value = "10")]
     batch_size: usize,

--- a/storage/src/raft_log_store/log.rs
+++ b/storage/src/raft_log_store/log.rs
@@ -191,6 +191,7 @@ impl Log {
                 }
                 file.write_all(&buf).await?;
                 let len = buf.len();
+                sync_size += len;
                 self.core
                     .active_file_len
                     .store(offset + len, Ordering::Release);


### PR DESCRIPTION
Bug introduced in #138 .

main:
```
Args: unknown
========== Bench Result ==========

Duration: 20.243s

Total Size: 955.1 kiB

Bandwidth: 47.2 kiB/s

========== Bench Result ==========
```

HEAD:

```plain
Args {
    path: ".run/tmp/bench",
    log_file_capacity: 4194304,
    block_cache_capacity: 67108864,
    groups: 100,
    entries: 10000,
    batch_size: 10,
    data_size: 64,
    context_size: 16,
    seed: 0,
    metrics: true,
    prometheus_host: "127.0.0.1",
    prometheus_port: 9898,
}
========== Bench Result ==========

Duration: 28.296s

Total Size: 85.4 MiB

Bandwidth: 3.0 MiB/s

========== Bench Result ==========
```

Ref: #138 #126 #132 .