### PR TITLE
feat: raft log store append raft log batch vec

### DIFF
--- a/etc/grafana-dashboards/runkv-overview.json
+++ b/etc/grafana-dashboards/runkv-overview.json
@@ -855,8 +855,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -986,8 +985,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -1137,8 +1135,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -1228,8 +1225,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -1352,8 +1348,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -1470,8 +1465,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -1561,8 +1555,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -1620,7 +1613,7 @@
         "x": 12,
         "y": 58
       },
-      "id": 31,
+      "id": 43,
       "options": {
         "content": "",
         "mode": "markdown"
@@ -1686,8 +1679,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -1804,8 +1796,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -1895,8 +1886,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -2020,8 +2010,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -2138,8 +2127,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -2242,8 +2230,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -2261,7 +2248,7 @@
         "x": 0,
         "y": 91
       },
-      "id": 22,
+      "id": 35,
       "options": {
         "legend": {
           "calcs": [],
@@ -2280,14 +2267,14 @@
             "uid": "PEDE6B306CC9C0CD0"
           },
           "editorMode": "code",
-          "expr": "sum(irate(raft_log_store_sync_duration_histogram_vec_count[1m])) by (instance)",
+          "expr": "sum(irate(raft_log_store_latency_histogram_vec_count[1m])) by (op)",
           "hide": false,
-          "legendFormat": "bandwitdh-{{instance}}",
+          "legendFormat": "{{op}}-ops",
           "range": true,
           "refId": "C"
         }
       ],
-      "title": "Sync - Instance Frequency",
+      "title": "OPs",
       "type": "timeseries"
     },
     {
@@ -2333,8 +2320,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -2372,11 +2358,11 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "histogram_quantile(0.5, avg(irate(raft_log_store_sync_duration_histogram_vec_bucket[1m])) by (le, instance))",
+          "expr": "histogram_quantile(0.5, avg(irate(raft_log_store_latency_histogram_vec_bucket[1m])) by (le, op))",
           "format": "time_series",
           "instant": false,
           "interval": "",
-          "legendFormat": "p50-{{instance}}",
+          "legendFormat": "{{op}}-p50",
           "range": true,
           "refId": "A"
         },
@@ -2386,9 +2372,9 @@
             "uid": "PEDE6B306CC9C0CD0"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.9, avg(irate(raft_log_store_sync_duration_histogram_vec_bucket[1m])) by (le, instance))",
+          "expr": "histogram_quantile(0.9, avg(irate(raft_log_store_latency_histogram_vec_bucket[1m])) by (le, op))",
           "hide": false,
-          "legendFormat": "p90-{{instance}}",
+          "legendFormat": "{{op}}-p90",
           "range": true,
           "refId": "B"
         },
@@ -2398,14 +2384,65 @@
             "uid": "PEDE6B306CC9C0CD0"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.99, avg(irate(raft_log_store_sync_duration_histogram_vec_bucket[1m])) by (le, instance))",
+          "expr": "histogram_quantile(0.99, avg(irate(raft_log_store_latency_histogram_vec_bucket[1m])) by (le, op))",
           "hide": false,
-          "legendFormat": "p99-{{instance}}",
+          "legendFormat": "{{op}}-p99",
           "range": true,
           "refId": "C"
         }
       ],
-      "title": "Sync - Instance Latency",
+      "title": "Latency",
+      "transformations": [
+        {
+          "id": "concatenate",
+          "options": {}
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {},
+            "indexByName": {
+              "append-p50": 1,
+              "append-p50 · Time": 0,
+              "append-p90": 3,
+              "append-p90 · Time": 2,
+              "append-p99": 5,
+              "append-p99 · Time": 4,
+              "append_log-p50": 13,
+              "append_log-p50 · Time": 12,
+              "append_log-p90": 15,
+              "append_log-p90 · Time": 14,
+              "append_log-p99": 17,
+              "append_log-p99 · Time": 16,
+              "block_cache_fill-p50": 31,
+              "block_cache_fill-p50 · Time": 30,
+              "block_cache_fill-p90": 33,
+              "block_cache_fill-p90 · Time": 32,
+              "block_cache_fill-p99": 35,
+              "block_cache_fill-p99 · Time": 34,
+              "block_cache_get-p50": 19,
+              "block_cache_get-p50 · Time": 18,
+              "block_cache_get-p90": 21,
+              "block_cache_get-p90 · Time": 20,
+              "block_cache_get-p99": 23,
+              "block_cache_get-p99 · Time": 22,
+              "block_cache_insert-p50": 25,
+              "block_cache_insert-p50 · Time": 24,
+              "block_cache_insert-p90": 27,
+              "block_cache_insert-p90 · Time": 26,
+              "block_cache_insert-p99": 29,
+              "block_cache_insert-p99 · Time": 28,
+              "sync-p50": 7,
+              "sync-p50 · Time": 6,
+              "sync-p90": 9,
+              "sync-p90 · Time": 8,
+              "sync-p99": 11,
+              "sync-p99 · Time": 10
+            },
+            "renameByName": {}
+          }
+        }
+      ],
       "type": "timeseries"
     },
     {
@@ -2419,7 +2456,7 @@
             "mode": "palette-classic"
           },
           "custom": {
-            "axisLabel": "Bandwidth",
+            "axisLabel": "Latency",
             "axisPlacement": "auto",
             "barAlignment": 0,
             "drawStyle": "line",
@@ -2451,8 +2488,214 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 99
+      },
+      "id": 36,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PEDE6B306CC9C0CD0"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "histogram_quantile(0.5, avg(irate(raft_log_store_latency_histogram_vec_bucket{ op=\"sync\" }[1m])) by (le, instance))",
+          "format": "time_series",
+          "instant": false,
+          "interval": "",
+          "legendFormat": "p50-{{instance}}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PEDE6B306CC9C0CD0"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.9, avg(irate(raft_log_store_latency_histogram_vec_bucket{ op=\"sync\" }[1m])) by (le, instance))",
+          "hide": false,
+          "legendFormat": "p90-{{instance}}",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PEDE6B306CC9C0CD0"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, avg(irate(raft_log_store_latency_histogram_vec_bucket{ op=\"sync\" }[1m])) by (le, instance))",
+          "hide": false,
+          "legendFormat": "p99-{{instance}}",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Sync - Instance Latency",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PEDE6B306CC9C0CD0"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "Frequency",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 99
+      },
+      "id": 22,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PEDE6B306CC9C0CD0"
+          },
+          "editorMode": "code",
+          "expr": "sum(irate(raft_log_store_latency_histogram_vec_count{ op=\"sync\" }[1m])) by (instance)",
+          "hide": false,
+          "legendFormat": "bandwitdh-{{instance}}",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Sync - Instance Frequency",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PEDE6B306CC9C0CD0"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "Throughput",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
               },
               {
                 "color": "red",
@@ -2468,7 +2711,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 99
+        "y": 107
       },
       "id": 24,
       "options": {
@@ -2489,14 +2732,14 @@
             "uid": "PEDE6B306CC9C0CD0"
           },
           "editorMode": "code",
-          "expr": "sum(irate(raft_log_store_sync_bytes_gauge_vec[1m])) by (instance)",
+          "expr": "sum(irate(raft_log_store_throughput_gauge_vec{ op=\"sync\" }[1m])) by (instance)",
           "hide": false,
           "legendFormat": "bandwitdh-{{instance}}",
           "range": true,
           "refId": "C"
         }
       ],
-      "title": "Sync - Instance Bytes",
+      "title": "Sync - Instance Throughput",
       "type": "timeseries"
     },
     {
@@ -2542,8 +2785,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -2559,7 +2801,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 99
+        "y": 107
       },
       "id": 25,
       "options": {
@@ -2589,6 +2831,875 @@
       ],
       "title": "Batch Writers - Instance Count",
       "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PEDE6B306CC9C0CD0"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "Latency",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 115
+      },
+      "id": 38,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PEDE6B306CC9C0CD0"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "histogram_quantile(0.5, avg(irate(raft_log_store_latency_histogram_vec_bucket{ op=\"append\" }[1m])) by (le, instance))",
+          "format": "time_series",
+          "instant": false,
+          "interval": "",
+          "legendFormat": "p50-{{instance}}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PEDE6B306CC9C0CD0"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.9, avg(irate(raft_log_store_latency_histogram_vec_bucket{ op=\"append\" }[1m])) by (le, instance))",
+          "hide": false,
+          "legendFormat": "p90-{{instance}}",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PEDE6B306CC9C0CD0"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, avg(irate(raft_log_store_latency_histogram_vec_bucket{ op=\"append\" }[1m])) by (le, instance))",
+          "hide": false,
+          "legendFormat": "p99-{{instance}}",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Append - Instance Latency",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PEDE6B306CC9C0CD0"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "Frequency",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 115
+      },
+      "id": 39,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PEDE6B306CC9C0CD0"
+          },
+          "editorMode": "code",
+          "expr": "sum(irate(raft_log_store_latency_histogram_vec_count{ op=\"append\" }[1m])) by (instance)",
+          "hide": false,
+          "legendFormat": "bandwitdh-{{instance}}",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Append - Instance Frequency",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PEDE6B306CC9C0CD0"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "Latency",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 123
+      },
+      "id": 37,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PEDE6B306CC9C0CD0"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "histogram_quantile(0.5, avg(irate(raft_log_store_latency_histogram_vec_bucket{ op=\"append_log\" }[1m])) by (le, instance))",
+          "format": "time_series",
+          "instant": false,
+          "interval": "",
+          "legendFormat": "p50-{{instance}}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PEDE6B306CC9C0CD0"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.9, avg(irate(raft_log_store_latency_histogram_vec_bucket{ op=\"append_log\" }[1m])) by (le, instance))",
+          "hide": false,
+          "legendFormat": "p90-{{instance}}",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PEDE6B306CC9C0CD0"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, avg(irate(raft_log_store_latency_histogram_vec_bucket{ op=\"append_log\" }[1m])) by (le, instance))",
+          "hide": false,
+          "legendFormat": "p99-{{instance}}",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Append Log - Instance Latency",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PEDE6B306CC9C0CD0"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "Frequency",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 123
+      },
+      "id": 40,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PEDE6B306CC9C0CD0"
+          },
+          "editorMode": "code",
+          "expr": "sum(irate(raft_log_store_latency_histogram_vec_count{ op=\"append_log\" }[1m])) by (instance)",
+          "hide": false,
+          "legendFormat": "bandwitdh-{{instance}}",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Append Log - Instance Frequency",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PEDE6B306CC9C0CD0"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "Throughput",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "binBps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 131
+      },
+      "id": 41,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PEDE6B306CC9C0CD0"
+          },
+          "editorMode": "code",
+          "expr": "sum(irate(raft_log_store_throughput_gauge_vec{ op=\"append_log\" }[1m])) by (instance)",
+          "hide": false,
+          "legendFormat": "bandwitdh-{{instance}}",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Append Log - Instance Throughput",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PEDE6B306CC9C0CD0"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 131
+      },
+      "id": 31,
+      "options": {
+        "content": "",
+        "mode": "markdown"
+      },
+      "pluginVersion": "8.5.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PEDE6B306CC9C0CD0"
+          },
+          "editorMode": "code",
+          "expr": "sum(irate(raft_latency_histogram_vec_count[1m])) by (op)",
+          "hide": false,
+          "legendFormat": "{{op}}-frequency",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "type": "text"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PEDE6B306CC9C0CD0"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "Latency",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 139
+      },
+      "id": 44,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PEDE6B306CC9C0CD0"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "histogram_quantile(0.5, avg(irate(raft_log_store_latency_histogram_vec_bucket{ op=~\"block_cache_.*\" }[1m])) by (le, op, instance))",
+          "format": "time_series",
+          "instant": false,
+          "interval": "",
+          "legendFormat": "{{op}}-p50-{{instance}}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PEDE6B306CC9C0CD0"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.9, avg(irate(raft_log_store_latency_histogram_vec_bucket{ op=~\"block_cache_.*\" }[1m])) by (le, op, instance))",
+          "hide": false,
+          "legendFormat": "{{op}}-p90-{{instance}}",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PEDE6B306CC9C0CD0"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, avg(irate(raft_log_store_latency_histogram_vec_bucket{ op=~\"block_cache_.*\" }[1m])) by (le, op, instance))",
+          "hide": false,
+          "legendFormat": "{{op}}-p99-{{instance}}",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Block Cache - Instance Latency",
+      "transformations": [
+        {
+          "id": "concatenate",
+          "options": {}
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {},
+            "indexByName": {
+              "block_cache_fill-p50-127.0.0.1:9898": 13,
+              "block_cache_fill-p50-127.0.0.1:9898 · Time": 12,
+              "block_cache_fill-p90-127.0.0.1:9898": 15,
+              "block_cache_fill-p90-127.0.0.1:9898 · Time": 14,
+              "block_cache_fill-p99-127.0.0.1:9898": 17,
+              "block_cache_fill-p99-127.0.0.1:9898 · Time": 16,
+              "block_cache_get-p50-127.0.0.1:9898": 1,
+              "block_cache_get-p50-127.0.0.1:9898 · Time": 0,
+              "block_cache_get-p90-127.0.0.1:9898": 3,
+              "block_cache_get-p90-127.0.0.1:9898 · Time": 2,
+              "block_cache_get-p99-127.0.0.1:9898": 5,
+              "block_cache_get-p99-127.0.0.1:9898 · Time": 4,
+              "block_cache_insert-p50-127.0.0.1:9898": 7,
+              "block_cache_insert-p50-127.0.0.1:9898 · Time": 6,
+              "block_cache_insert-p90-127.0.0.1:9898": 9,
+              "block_cache_insert-p90-127.0.0.1:9898 · Time": 8,
+              "block_cache_insert-p99-127.0.0.1:9898": 11,
+              "block_cache_insert-p99-127.0.0.1:9898 · Time": 10
+            },
+            "renameByName": {}
+          }
+        }
+      ],
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PEDE6B306CC9C0CD0"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "Frequency",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 139
+      },
+      "id": 45,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PEDE6B306CC9C0CD0"
+          },
+          "editorMode": "code",
+          "expr": "sum(irate(raft_log_store_latency_histogram_vec_count{ op=~\"block_cache_.*\" }[1m])) by (op, instance)",
+          "hide": false,
+          "legendFormat": "{{op}}-{{instance}}",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Block Cache - Instance Frequency",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PEDE6B306CC9C0CD0"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "Rate",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "max": 1,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 147
+      },
+      "id": 46,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PEDE6B306CC9C0CD0"
+          },
+          "editorMode": "code",
+          "expr": "sum(irate(raft_log_store_latency_histogram_vec_count{ op=\"block_cache_fill\" }[1m])) by (instance) / sum(irate(raft_log_store_latency_histogram_vec_count{ op=\"block_cache_get\" }[1m])) by (instance)",
+          "hide": false,
+          "legendFormat": "miss-{{instance}}",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Block Cache - Cache Miss Rate",
+      "type": "timeseries"
     }
   ],
   "refresh": "10s",
@@ -2599,7 +3710,7 @@
     "list": []
   },
   "time": {
-    "from": "now-15m",
+    "from": "now-30m",
     "to": "now"
   },
   "timepicker": {},

--- a/storage/bench/bench_raft_log_store.rs
+++ b/storage/bench/bench_raft_log_store.rs
@@ -144,9 +144,7 @@ async fn main() {
                         builder.add(group, term, index, &ctx, &data);
                     }
                     let log_batches = builder.build();
-                    for log_batch in log_batches {
-                        raft_log_store_clone.append(log_batch).await.unwrap();
-                    }
+                    raft_log_store_clone.append(log_batches).await.unwrap();
                 }
             }
         })

--- a/storage/src/raft_log_store/block_cache.rs
+++ b/storage/src/raft_log_store/block_cache.rs
@@ -1,9 +1,11 @@
 use std::sync::Arc;
+use std::time::Instant;
 
 use futures::Future;
 use moka::future::Cache;
 
 use super::error::RaftLogStoreError;
+use super::metrics::RaftLogStoreMetricsRef;
 use super::DEFAULT_LOG_BATCH_SIZE;
 use crate::error::Result;
 
@@ -15,28 +17,46 @@ struct BlockIndex {
 
 pub struct BlockCache {
     inner: Cache<BlockIndex, Arc<Vec<u8>>>,
+    metrics: RaftLogStoreMetricsRef,
 }
 
 impl BlockCache {
-    pub fn new(capacity: usize) -> Self {
+    pub fn new(capacity: usize, metrics: RaftLogStoreMetricsRef) -> Self {
         let cache: Cache<BlockIndex, Arc<Vec<u8>>> = Cache::builder()
             .weigher(|_k, v: &Arc<Vec<u8>>| v.len() as u32)
             .initial_capacity(capacity / DEFAULT_LOG_BATCH_SIZE)
             .max_capacity(capacity as u64)
             .build();
-        Self { inner: cache }
+        Self {
+            inner: cache,
+            metrics,
+        }
     }
 
     #[tracing::instrument(level = "trace", skip(self))]
     pub fn get(&self, file_id: u64, offset: usize) -> Option<Arc<Vec<u8>>> {
-        self.inner.get(&BlockIndex { file_id, offset })
+        let start = Instant::now();
+
+        let result = self.inner.get(&BlockIndex { file_id, offset });
+
+        self.metrics
+            .block_cache_get_latency_histogram
+            .observe(start.elapsed().as_secs_f64());
+
+        result
     }
 
     #[tracing::instrument(level = "trace", skip(self, block))]
     pub async fn insert(&self, file_id: u64, offset: usize, block: Arc<Vec<u8>>) {
+        let start = Instant::now();
+
         self.inner
             .insert(BlockIndex { file_id, offset }, block)
-            .await
+            .await;
+
+        self.metrics
+            .block_cache_insert_latency_histogram
+            .observe(start.elapsed().as_secs_f64());
     }
 
     #[tracing::instrument(level = "trace", skip(self, f))]
@@ -49,13 +69,33 @@ impl BlockCache {
     where
         F: Future<Output = Result<Arc<Vec<u8>>>>,
     {
-        match self
+        let future = async move {
+            let start_fill = Instant::now();
+
+            let r = f.await;
+
+            self.metrics
+                .block_cache_fill_latency_histogram
+                .observe(start_fill.elapsed().as_secs_f64());
+
+            r
+        };
+
+        let start = Instant::now();
+
+        let result = match self
             .inner
-            .get_or_try_insert_with(BlockIndex { file_id, offset }, f)
+            .get_or_try_insert_with(BlockIndex { file_id, offset }, future)
             .await
         {
-            Ok(block) => Ok(block),
-            Err(arc_error) => Err(RaftLogStoreError::Other(arc_error.to_string()).into()),
-        }
+            Ok(block) => block,
+            Err(arc_error) => return Err(RaftLogStoreError::Other(arc_error.to_string()).into()),
+        };
+
+        self.metrics
+            .block_cache_get_latency_histogram
+            .observe(start.elapsed().as_secs_f64());
+
+        Ok(result)
     }
 }

--- a/storage/src/raft_log_store/metrics.rs
+++ b/storage/src/raft_log_store/metrics.rs
@@ -3,18 +3,25 @@ use std::sync::Arc;
 use lazy_static::lazy_static;
 
 lazy_static! {
-    static ref RAFT_LOG_STORE_SYNC_DURATION_HISTOGRAM_VEC: prometheus::HistogramVec =
+    static ref RAFT_LOG_STORE_LATENCY_HISTOGRAM_VEC: prometheus::HistogramVec =
         prometheus::register_histogram_vec!(
-            "raft_log_store_sync_duration_histogram_vec",
-            "raft log store sync duration histogram vec",
-            &["node"]
+            "raft_log_store_latency_histogram_vec",
+            "raft log store latency histogram vec",
+            &["op", "node"]
         )
         .unwrap();
-    static ref RAFT_LOG_STORE_SYNC_BYTES_GAUGE_VEC: prometheus::GaugeVec =
+    static ref RAFT_LOG_STORE_THROUGHPUT_GAUGE_VEC: prometheus::GaugeVec =
         prometheus::register_gauge_vec!(
-            "raft_log_store_sync_bytes_gauge_vec",
-            "raft log store sync bytes guage vec",
-            &["node"]
+            "raft_log_store_throughput_gauge_vec",
+            "raft log store throughput guage vec",
+            &["op", "node"]
+        )
+        .unwrap();
+    static ref RAFT_LOG_STORE_OP_COUNTER_VEC: prometheus::CounterVec =
+        prometheus::register_counter_vec!(
+            "raft_log_store_op_counter_vec",
+            "raft log store op counter vec",
+            &["op", "node"]
         )
         .unwrap();
     static ref RAFT_LOG_STORE_BATCH_WRITERS_HISTOGRAM_VEC: prometheus::HistogramVec =
@@ -27,9 +34,19 @@ lazy_static! {
 }
 
 pub struct RaftLogStoreMetrics {
-    pub sync_duration_histogram: prometheus::Histogram,
-    pub sync_bytes_guage: prometheus::Gauge,
+    pub sync_latency_histogram: prometheus::Histogram,
+    pub sync_throughput_guage: prometheus::Gauge,
+
+    pub append_latency_histogram: prometheus::Histogram,
+
+    pub append_log_latency_histogram: prometheus::Histogram,
+    pub append_log_throughput_guage: prometheus::Gauge,
+
     pub batch_writers_histogram: prometheus::Histogram,
+
+    pub block_cache_get_latency_histogram: prometheus::Histogram,
+    pub block_cache_insert_latency_histogram: prometheus::Histogram,
+    pub block_cache_fill_latency_histogram: prometheus::Histogram,
 }
 
 pub type RaftLogStoreMetricsRef = Arc<RaftLogStoreMetrics>;
@@ -37,12 +54,34 @@ pub type RaftLogStoreMetricsRef = Arc<RaftLogStoreMetrics>;
 impl RaftLogStoreMetrics {
     pub fn new(node: u64) -> Self {
         Self {
-            sync_duration_histogram: RAFT_LOG_STORE_SYNC_DURATION_HISTOGRAM_VEC
-                .get_metric_with_label_values(&[&node.to_string()])
+            sync_latency_histogram: RAFT_LOG_STORE_LATENCY_HISTOGRAM_VEC
+                .get_metric_with_label_values(&["sync", &node.to_string()])
                 .unwrap(),
-            sync_bytes_guage: RAFT_LOG_STORE_SYNC_BYTES_GAUGE_VEC
-                .get_metric_with_label_values(&[&node.to_string()])
+            sync_throughput_guage: RAFT_LOG_STORE_THROUGHPUT_GAUGE_VEC
+                .get_metric_with_label_values(&["sync", &node.to_string()])
                 .unwrap(),
+
+            append_latency_histogram: RAFT_LOG_STORE_LATENCY_HISTOGRAM_VEC
+                .get_metric_with_label_values(&["append", &node.to_string()])
+                .unwrap(),
+
+            append_log_latency_histogram: RAFT_LOG_STORE_LATENCY_HISTOGRAM_VEC
+                .get_metric_with_label_values(&["append_log", &node.to_string()])
+                .unwrap(),
+            append_log_throughput_guage: RAFT_LOG_STORE_THROUGHPUT_GAUGE_VEC
+                .get_metric_with_label_values(&["append_log", &node.to_string()])
+                .unwrap(),
+
+            block_cache_get_latency_histogram: RAFT_LOG_STORE_LATENCY_HISTOGRAM_VEC
+                .get_metric_with_label_values(&["block_cache_get", &node.to_string()])
+                .unwrap(),
+            block_cache_insert_latency_histogram: RAFT_LOG_STORE_LATENCY_HISTOGRAM_VEC
+                .get_metric_with_label_values(&["block_cache_insert", &node.to_string()])
+                .unwrap(),
+            block_cache_fill_latency_histogram: RAFT_LOG_STORE_LATENCY_HISTOGRAM_VEC
+                .get_metric_with_label_values(&["block_cache_fill", &node.to_string()])
+                .unwrap(),
+
             batch_writers_histogram: RAFT_LOG_STORE_BATCH_WRITERS_HISTOGRAM_VEC
                 .get_metric_with_label_values(&[&node.to_string()])
                 .unwrap(),

--- a/storage/src/raft_log_store/store.rs
+++ b/storage/src/raft_log_store/store.rs
@@ -5,7 +5,7 @@ use tracing::trace;
 
 use super::block_cache::BlockCache;
 use super::entry::{Compact, Entry as LogEntry, Kv, Mask, RaftLogBatch, Truncate};
-use super::log::{Log, LogOptions, WriteHandle};
+use super::log::{Log, LogOptions};
 use super::mem::{EntryIndex, MemStates};
 use super::metrics::{RaftLogStoreMetrics, RaftLogStoreMetricsRef};
 use crate::error::Result;
@@ -25,6 +25,15 @@ pub struct RaftLogStoreOptions {
     pub log_dir_path: String,
     pub log_file_capacity: usize,
     pub block_cache_capacity: usize,
+}
+
+struct AppendContext {
+    group: u64,
+    first_index: u64,
+    raw: Vec<u8>,
+    data_segment_offset: usize,
+    data_segment_len: usize,
+    indices: Vec<EntryIndex>,
 }
 
 struct RaftLogStoreCore {
@@ -137,49 +146,71 @@ impl RaftLogStore {
     }
 
     /// Append raft log batch to [`RaftLogStore`].
-    pub async fn append(&self, mut batch: RaftLogBatch) -> Result<()> {
-        let (data_segment_offset, data_segment_len) = batch.data_segment_location();
-        let group = batch.group();
-        let term = batch.term();
-        let first_index = batch.first_index();
+    pub async fn append(&self, batches: Vec<RaftLogBatch>) -> Result<()> {
+        let mut ctxs = Vec::with_capacity(batches.len());
+        let mut entries = Vec::with_capacity(batches.len());
 
-        let mut indices = Vec::with_capacity(batch.len());
-        for i in 0..batch.len() {
-            let (offset, len) = batch.location(i);
-            let index = EntryIndex {
-                term,
-                ctx: batch.ctx(i).to_vec(),
-                file_id: 0,
-                block_offset: 0,
-                block_len: 0,
-                offset,
-                len,
-            };
-            indices.push(index);
+        for mut batch in batches {
+            // Initialize entry indices before write log.
+            let mut indices = Vec::with_capacity(batch.len());
+            let (data_segment_offset, data_segment_len) = batch.data_segment_location();
+            let group = batch.group();
+            let term = batch.term();
+            let first_index = batch.first_index();
+            for i in 0..batch.len() {
+                let (offset, len) = batch.location(i);
+                let index = EntryIndex {
+                    term,
+                    ctx: batch.ctx(i).to_vec(),
+                    file_id: 0,
+                    block_offset: 0,
+                    block_len: 0,
+                    offset,
+                    len,
+                };
+                indices.push(index);
+            }
+
+            // Collect write entries.
+            let raw = batch.take_raw();
+            let entry = LogEntry::RaftLogBatch(batch);
+
+            entries.push(entry);
+            ctxs.push(AppendContext {
+                group,
+                first_index,
+                raw,
+                data_segment_offset,
+                data_segment_len,
+                indices,
+            });
         }
 
-        let raw = batch.take_raw();
-        let entry = LogEntry::RaftLogBatch(batch);
-        let WriteHandle {
-            file_id,
-            offset: write_offset,
-            len: _,
-        } = self.core.log.append(vec![entry]).await?;
+        // Append log.
+        let handles = self.core.log.append(entries).await?;
 
-        let block_offset = write_offset + data_segment_offset + 1;
-        let block_len = data_segment_len;
-        for index in indices.iter_mut() {
-            index.file_id = file_id;
-            index.block_offset = block_offset;
-            index.block_len = block_len;
+        for (mut ctx, handle) in ctxs.into_iter().zip(handles.into_iter()) {
+            let file_id = handle.file_id;
+            let block_offset = handle.offset + ctx.data_segment_offset + 1;
+            let block_len = ctx.data_segment_len;
+            for index in ctx.indices.iter_mut() {
+                index.file_id = file_id;
+                index.block_offset = block_offset;
+                index.block_len = block_len;
+            }
+
+            // Fill block cache.
+            self.core
+                .block_cache
+                .insert(file_id, block_offset, Arc::new(ctx.raw))
+                .await;
+
+            // Update memory states.
+            self.core
+                .states
+                .append(ctx.group, ctx.first_index, ctx.indices)
+                .await?;
         }
-
-        self.core
-            .block_cache
-            .insert(file_id, block_offset, Arc::new(raw))
-            .await;
-
-        self.core.states.append(group, first_index, indices).await?;
 
         Ok(())
     }
@@ -391,7 +422,9 @@ mod tests {
         store.add_group(3).await.unwrap();
         store.add_group(4).await.unwrap();
         for batch in batches {
-            store.append(batch).await.unwrap();
+            // FIXME: Currently one log writer cannot rotate log file internally, so we need to
+            // append batch one by one.
+            store.append(vec![batch]).await.unwrap();
         }
         assert_eq!(store.core.log.frozen_file_count().await, 4);
         for group in 1..=4 {

--- a/wheel/src/components/raft_log_store.rs
+++ b/wheel/src/components/raft_log_store.rs
@@ -52,8 +52,8 @@ impl RaftGroupLogStore {
         Self { group, core }
     }
 
-    pub async fn append(&self, batch: RaftLogBatch) -> Result<()> {
-        self.core.append(batch).await.map_err(Error::StorageError)
+    pub async fn append(&self, batches: Vec<RaftLogBatch>) -> Result<()> {
+        self.core.append(batches).await.map_err(Error::StorageError)
     }
 
     pub async fn put(&self, key: Vec<u8>, value: Vec<u8>) -> Result<()> {
@@ -282,10 +282,9 @@ mod tests {
 
         let mut builder = RaftLogBatchBuilder::default();
         builder.add(1, 1, 1, &[b'c'; 16], &[b'd'; 16]);
-        let mut batches = builder.build();
-        let batch = batches.remove(0);
+        let batches = builder.build();
 
-        raft_node.append(batch).await.unwrap();
+        raft_node.append(batches).await.unwrap();
 
         let l1 = raft_node.last_index().await;
         let l2 = raft_node_clone.last_index().await;

--- a/wheel/src/components/raft_manager.rs
+++ b/wheel/src/components/raft_manager.rs
@@ -106,6 +106,7 @@ impl RaftManager {
     pub async fn create_raft_node(&self, group: u64, raft_node: u64) -> Result<()> {
         // Build Lsm-tree.
         let lsm_tree_options = ObjectStoreLsmTreeOptions {
+            raft_node,
             sstable_store: self.sstable_store.clone(),
             write_buffer_capacity: self.lsm_tree_options.write_buffer_capacity,
             version_manager: self.version_manager.clone(),

--- a/wheel/src/worker/raft.rs
+++ b/wheel/src/worker/raft.rs
@@ -332,7 +332,7 @@ where
         }
     }
 
-    #[tracing::instrument(level = "trace")]
+    // #[tracing::instrument(level = "trace")]
     async fn tick(&mut self) {
         self.raft.tick().await;
     }
@@ -506,9 +506,7 @@ where
             batches.len(),
             batches
         );
-        for batch in batches {
-            self.raft_log_store.append(batch).await?;
-        }
+        self.raft_log_store.append(batches).await?;
         let elapsed = start.elapsed();
         self.metrics
             .append_log_entries_latency_histogram


### PR DESCRIPTION
As titled. 

Now raft log store `append` receives a vector of raft log batch.

More metrics for raft log store are added.

Ref: #126 .