### PR TITLE
fix: heartbeat raise error if no version diff

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1444,6 +1444,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "matches"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2139,6 +2148,9 @@ name = "regex-automata"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax",
+]
 
 [[package]]
 name = "regex-syntax"
@@ -2212,6 +2224,7 @@ dependencies = [
  "toml",
  "tonic",
  "tracing",
+ "tracing-appender",
  "tracing-opentelemetry",
  "tracing-subscriber",
 ]
@@ -3083,6 +3096,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-appender"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09d48f71a791638519505cefafe162606f706c25592e4bde4d97600c0195312e"
+dependencies = [
+ "crossbeam-channel",
+ "time 0.3.7",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "tracing-attributes"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3144,9 +3168,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4bc28f93baff38037f64e6f43d34cfa1605f27a49c34e8a04c5e78b0babf2596"
 dependencies = [
  "ansi_term",
+ "lazy_static",
+ "matchers",
+ "regex",
  "sharded-slab",
  "smallvec",
  "thread_local",
+ "tracing",
  "tracing-core",
  "tracing-log",
 ]

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -37,8 +37,9 @@ tokio = { version = "1", features = ["rt-multi-thread", "sync"] }
 toml = "0.4.2"
 tonic = "0.6.2"
 tracing = "0.1"
+tracing-appender = "0.2"
 tracing-opentelemetry = "0.17"
-tracing-subscriber = "0.3"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [dev-dependencies]
 env_logger = "*"

--- a/common/src/log.rs
+++ b/common/src/log.rs
@@ -1,29 +1,41 @@
 use isahc::config::Configurable;
-use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::filter::{EnvFilter, Targets};
+use tracing_subscriber::layer::{Layer, SubscriberExt};
 use tracing_subscriber::util::SubscriberInitExt;
-use tracing_subscriber::Layer;
 
-pub fn init_runkv_logger(service_name: &str) {
-    let enable_jaeger_tracing = match std::env::var("RUNKV_TRACE") {
+pub struct LogGuard {
+    _file_appender_guard: tracing_appender::non_blocking::WorkerGuard,
+    jaeger_enabled: bool,
+}
+
+impl Drop for LogGuard {
+    fn drop(&mut self) {
+        if self.jaeger_enabled {
+            opentelemetry::global::shutdown_tracer_provider();
+        }
+    }
+}
+
+pub fn init_runkv_logger(service: &str, id: u64, log_path: &str) -> LogGuard {
+    let jaeger_enabled = match std::env::var("RUNKV_TRACE") {
         Err(_) => false,
         Ok(val) => val.parse().unwrap(),
     };
 
-    if enable_jaeger_tracing {
-        opentelemetry::global::set_text_map_propagator(opentelemetry_jaeger::Propagator::new());
+    let (file_appender, file_appender_guard) = tracing_appender::non_blocking(
+        tracing_appender::rolling::daily(log_path, format!("runkv-{}-{}.log", service, id)),
+    );
 
-        let tracer = opentelemetry_jaeger::new_pipeline()
-            // TODO: use UDP tracing in production environment
-            .with_collector_endpoint("http://127.0.0.1:14268/api/traces")
-            // TODO: change service name to compute-{port}
-            .with_service_name(service_name)
-            // disable proxy
-            .with_http_client(isahc::HttpClient::builder().proxy(None).build().unwrap())
-            .install_batch(opentelemetry::runtime::Tokio)
-            .unwrap();
+    let guard = LogGuard {
+        _file_appender_guard: file_appender_guard,
+        jaeger_enabled,
+    };
 
+    let logger = tracing_subscriber::registry().with(EnvFilter::from_default_env());
+
+    let fmt_layer = {
         // Configure RunKV's own crates to log at TRACE level, and ignore all third-party crates.
-        let filter = tracing_subscriber::filter::Targets::new()
+        let filter = Targets::new()
             // Enable trace for most modules.
             .with_target("runkv_common", tracing::Level::TRACE)
             .with_target("runkv_storage", tracing::Level::TRACE)
@@ -33,25 +45,51 @@ pub fn init_runkv_logger(service_name: &str) {
             .with_target("runkv_tests", tracing::Level::TRACE)
             .with_target("openraft::raft", tracing::Level::TRACE)
             .with_target("raft", tracing::Level::TRACE)
-            .with_target("events", tracing::Level::ERROR);
+            .with_target("events", tracing::Level::WARN);
+
+        tracing_subscriber::fmt::layer()
+            .with_test_writer()
+            .with_writer(file_appender)
+            .with_ansi(false)
+            .with_filter(filter)
+    };
+
+    let logger = logger.with(fmt_layer);
+
+    if jaeger_enabled {
+        opentelemetry::global::set_text_map_propagator(opentelemetry_jaeger::Propagator::new());
+
+        // Configure RunKV's own crates to log at TRACE level, and ignore all third-party crates.
+        let filter = Targets::new()
+            // Enable trace for most modules.
+            .with_target("runkv_common", tracing::Level::TRACE)
+            .with_target("runkv_storage", tracing::Level::TRACE)
+            .with_target("runkv_rudder", tracing::Level::TRACE)
+            .with_target("runkv_wheel", tracing::Level::TRACE)
+            .with_target("runkv_exhauster", tracing::Level::TRACE)
+            .with_target("runkv_tests", tracing::Level::TRACE)
+            .with_target("openraft::raft", tracing::Level::TRACE)
+            .with_target("raft", tracing::Level::TRACE)
+            .with_target("events", tracing::Level::WARN);
+
+        let tracer = opentelemetry_jaeger::new_pipeline()
+            // TODO: use UDP tracing in production environment
+            .with_collector_endpoint("http://127.0.0.1:14268/api/traces")
+            // TODO: change service name to compute-{port}
+            .with_service_name(service)
+            // disable proxy
+            .with_http_client(isahc::HttpClient::builder().proxy(None).build().unwrap())
+            .install_batch(opentelemetry::runtime::Tokio)
+            .unwrap();
 
         let opentelemetry_layer = tracing_opentelemetry::layer()
             .with_tracer(tracer)
             .with_filter(filter);
 
-        tracing_subscriber::registry()
-            .with(opentelemetry_layer)
-            .init();
+        logger.with(opentelemetry_layer).init();
+    } else {
+        logger.init();
     }
-}
 
-pub fn shutdown_runkv_logger() {
-    let enable_jaeger_tracing = match std::env::var("RUNKV_TRACE") {
-        Err(_) => false,
-        Ok(val) => val.parse().unwrap(),
-    };
-
-    if enable_jaeger_tracing {
-        opentelemetry::global::shutdown_tracer_provider();
-    }
+    guard
 }

--- a/etc/grafana-dashboards/runkv-overview.json
+++ b/etc/grafana-dashboards/runkv-overview.json
@@ -855,7 +855,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -985,7 +986,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -1079,6 +1081,18 @@
               "apply_log_entries-p90 · Time": 14,
               "apply_log_entries-p99": 17,
               "apply_log_entries-p99 · Time": 16,
+              "handle_ready-p50": 19,
+              "handle_ready-p50 · Time": 18,
+              "handle_ready-p90": 21,
+              "handle_ready-p90 · Time": 20,
+              "handle_ready-p99": 23,
+              "handle_ready-p99 · Time": 22,
+              "poll_channel-p50": 25,
+              "poll_channel-p50 · Time": 24,
+              "poll_channel-p90": 27,
+              "poll_channel-p90 · Time": 26,
+              "poll_channel-p99": 29,
+              "poll_channel-p99 · Time": 28,
               "send_messages-p50": 7,
               "send_messages-p50 · Time": 6,
               "send_messages-p90": 9,
@@ -1135,7 +1149,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -1225,7 +1240,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -1348,7 +1364,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -1465,7 +1482,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",

--- a/etc/wheel.toml
+++ b/etc/wheel.toml
@@ -1,6 +1,7 @@
 id = 101
 host = "127.0.0.1"
 port = 12401
+log = ".run/log/"
 data_path = "data"
 meta_path = "meta"
 poll_interval = "100ms"

--- a/storage/src/raft_log_store/store.rs
+++ b/storage/src/raft_log_store/store.rs
@@ -64,6 +64,7 @@ impl RaftLogStore {
         let metrics = Arc::new(RaftLogStoreMetrics::new(options.node));
 
         let log_options = LogOptions {
+            node: options.node,
             path: options.log_dir_path,
             log_file_capacity: options.log_file_capacity,
 

--- a/tests/etc/wheel.toml
+++ b/tests/etc/wheel.toml
@@ -1,6 +1,7 @@
 id = 101
 host = "127.0.0.1"
 port = 0
+log = ".run/log/"
 data_path = "data"
 meta_path = "meta"
 poll_interval = "100ms"

--- a/tests/integrations/test_concurrent_put_get.rs
+++ b/tests/integrations/test_concurrent_put_get.rs
@@ -11,7 +11,8 @@ use std::time::Duration;
 use futures::future;
 use itertools::Itertools;
 use rand::{thread_rng, Rng};
-use runkv_common::log::{init_runkv_logger, shutdown_runkv_logger};
+use runkv_common::log::init_runkv_logger;
+use runkv_common::time::timestamp;
 use runkv_exhauster::config::ExhausterConfig;
 use runkv_exhauster::{bootstrap_exhauster, build_exhauster_with_object_store};
 use runkv_proto::common::Endpoint;
@@ -63,9 +64,13 @@ async fn add_key_ranges(wheel_client: &mut WheelServiceClient<Channel>, node: u6
     add_key_range(wheel_client, b"k0", b"kz", 10, &[11, 12, 13], node).await;
 }
 
-#[test(tokio::test)]
+#[tokio::test]
 async fn test_concurrent_put_get() {
-    init_runkv_logger("runkv_tests");
+    let _log = init_runkv_logger(
+        "tests",
+        0,
+        &format!("../.run/tmp/test_concurrent_put_get_log/{}/", timestamp()),
+    );
 
     let mut port = crate::port("test_concurrent_put_get");
 

--- a/tests/integrations/test_multi_raft_group_concurrent_put_get.rs
+++ b/tests/integrations/test_multi_raft_group_concurrent_put_get.rs
@@ -10,7 +10,8 @@ use std::time::Duration;
 use futures::future;
 use itertools::Itertools;
 use rand::{thread_rng, Rng};
-use runkv_common::log::{init_runkv_logger, shutdown_runkv_logger};
+use runkv_common::log::init_runkv_logger;
+use runkv_common::time::timestamp;
 use runkv_exhauster::config::ExhausterConfig;
 use runkv_exhauster::{bootstrap_exhauster, build_exhauster_with_object_store};
 use runkv_proto::common::Endpoint;
@@ -71,9 +72,16 @@ async fn add_key_ranges(wheel_client: &mut WheelServiceClient<Channel>, node: u6
     add_key_range(wheel_client, b"k9", b"k9z", 100, &[101, 102, 103], node).await;
 }
 
-#[test(tokio::test)]
+#[tokio::test]
 async fn test_multi_raft_group_concurrent_put_get() {
-    init_runkv_logger("runkv_tests");
+    let _log = init_runkv_logger(
+        "tests",
+        0,
+        &format!(
+            "../.run/tmp/test_multi_raft_group_concurrent_put_get/{}/",
+            timestamp()
+        ),
+    );
 
     let mut port = crate::port("test_multi_raft_group_concurrent_put_get");
 

--- a/wheel/src/config.rs
+++ b/wheel/src/config.rs
@@ -8,6 +8,7 @@ pub struct WheelConfig {
     pub id: u64,
     pub host: String,
     pub port: u16,
+    pub log: String,
     pub data_path: String,
     pub meta_path: String,
     pub poll_interval: String,

--- a/wheel/src/service.rs
+++ b/wheel/src/service.rs
@@ -192,7 +192,6 @@ impl Wheel {
 
     #[tracing::instrument(level = "trace", fields(request_id))]
     async fn txn_inner(&self, request: TxnRequest) -> Result<TxnResponse> {
-        let now = std::time::Instant::now();
         let span = tracing::Span::current();
         let span_id = span.id();
         // Pick raft leader of the request.
@@ -256,7 +255,7 @@ impl Wheel {
             .instrument(trace_span!("wait_apply"))
             .await
             .map_err(Error::err)?;
-        tracing::info!("txn inner takes: {:?}", now.elapsed());
+
         response
     }
 

--- a/wheel/src/worker/heartbeater.rs
+++ b/wheel/src/worker/heartbeater.rs
@@ -70,6 +70,7 @@ impl Heartbeater {
                 },
             )),
         });
+
         let mut client = RudderServiceClient::new(
             self.channel_pool
                 .get(self.rudder_node_id)


### PR DESCRIPTION
Changes:
- Add an empty `VersionDiff` when rudder start, or heartbeater will raise a `VersionDiffExpired` error and immediately send another heartbeat.
- Add more tracing and metrics.
- Add file log support.