### PR TITLE
feat: introduce runkv client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2237,6 +2237,7 @@ dependencies = [
  "itertools",
  "lazy_static",
  "rand",
+ "runkv-client",
  "runkv-common",
  "runkv-exhauster",
  "runkv-proto",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2256,9 +2256,16 @@ dependencies = [
 name = "runkv-client"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
+ "async-trait",
+ "itertools",
+ "parking_lot 0.12.0",
  "runkv-common",
  "runkv-proto",
+ "thiserror",
+ "tokio",
  "tonic",
+ "tracing",
 ]
 
 [[package]]

--- a/bench/Cargo.toml
+++ b/bench/Cargo.toml
@@ -14,6 +14,7 @@ futures = "0.3"
 itertools = "0.10.3"
 lazy_static = "1.4.0"
 rand = "0.8.5"
+runkv-client = { path = "../client" }
 runkv-common = { path = "../common" }
 runkv-exhauster = { path = "../exhauster" }
 runkv-proto = { path = "../proto" }

--- a/bench/bench_kv/main.rs
+++ b/bench/bench_kv/main.rs
@@ -166,6 +166,7 @@ impl ClusterInitializer {
             group,
             key_range: Some(KeyRange { start_key, end_key }),
             raft_nodes,
+            leader: 0,
         });
     }
 

--- a/bench/bench_kv/main.rs
+++ b/bench/bench_kv/main.rs
@@ -1,3 +1,4 @@
+use runkv_client::client::{RunkvClient, RunkvClientOptions};
 use runkv_proto::rudder::control_service_client::ControlServiceClient;
 use runkv_proto::rudder::{AddKeyRangesRequest, AddWheelsRequest};
 #[cfg(not(target_env = "msvc"))]
@@ -22,8 +23,6 @@ use runkv_common::time::timestamp;
 use runkv_exhauster::config::ExhausterConfig;
 use runkv_exhauster::{bootstrap_exhauster, build_exhauster_with_object_store};
 use runkv_proto::common::Endpoint;
-use runkv_proto::kv::kv_service_client::KvServiceClient;
-use runkv_proto::kv::{DeleteRequest, GetRequest, PutRequest};
 use runkv_proto::meta::{KeyRange, KeyRangeInfo};
 use runkv_rudder::config::RudderConfig;
 use runkv_rudder::{bootstrap_rudder, build_rudder_with_object_store};
@@ -185,37 +184,17 @@ impl ClusterInitializer {
     }
 }
 
-async fn assert_put(client: &mut KvServiceClient<Channel>, key: Vec<u8>, value: Vec<u8>) {
-    client
-        .put(Request::new(PutRequest { key, value }))
-        .await
-        .unwrap();
+async fn assert_put(client: &RunkvClient, key: Vec<u8>, value: Vec<u8>) {
+    client.put(key, value).await.unwrap();
 }
 
-async fn assert_get(
-    client: &mut KvServiceClient<Channel>,
-    key: Vec<u8>,
-    expected: Option<Vec<u8>>,
-) {
-    let result = client
-        .get(Request::new(GetRequest { key, sequence: 0 }))
-        .await
-        .unwrap()
-        .into_inner()
-        .value;
-    let result = if result.is_empty() {
-        None
-    } else {
-        Some(result)
-    };
+async fn assert_get(client: &RunkvClient, key: Vec<u8>, expected: Option<Vec<u8>>) {
+    let result = client.get(key).await.unwrap();
     assert_eq!(result, expected);
 }
 
-async fn assert_delete(client: &mut KvServiceClient<Channel>, key: Vec<u8>) {
-    client
-        .delete(Request::new(DeleteRequest { key }))
-        .await
-        .unwrap();
+async fn assert_delete(client: &RunkvClient, key: Vec<u8>) {
+    client.delete(key).await.unwrap();
 }
 
 async fn mkdir_if_not_exists(path: &str) {
@@ -364,43 +343,41 @@ async fn main() {
     }
     initializer.init().await;
 
-    let channel = tonic::transport::Endpoint::from_shared(format!(
-        "http://{}:{}",
-        // TODO: Support multi wheels.
-        LOCALHOST,
-        1 + WHEEL_PORT_BASE,
-    ))
-    .unwrap()
-    .connect()
-    .await
-    .unwrap();
+    let runkv_client = RunkvClient::open(RunkvClientOptions {
+        rudder: rudder_config.id,
+        rudder_host: rudder_config.host.clone(),
+        rudder_port: rudder_config.port,
+        heartbeat_interval: Duration::from_nanos(0),
+    })
+    .await;
+    runkv_client.update_router().await.unwrap();
 
     let futures = (1..=args.groups)
         .flat_map(|group| {
-            let channel_clone = channel.clone();
+            let runkv_client_clone = runkv_client.clone();
             (1..=args.concurrency).map(move |c| {
-                let channel_clone_clone = channel_clone.clone();
+                let client_clone = runkv_client_clone.clone();
                 async move {
                     let mut rng = thread_rng();
 
-                    let mut client = KvServiceClient::new(channel_clone_clone);
+                    let client = client_clone.clone();
 
                     let key = key(group, c, args.key_size);
                     let value = value(group, c, args.value_size);
 
                     for _ in 0..args.r#loop {
                         tokio::time::sleep(Duration::from_millis(rng.gen_range(0..10))).await;
-                        assert_put(&mut client, key.clone(), value.clone()).await;
+                        assert_put(&client, key.clone(), value.clone()).await;
                         tokio::time::sleep(Duration::from_millis(rng.gen_range(0..10))).await;
-                        assert_get(&mut client, key.clone(), Some(value.clone())).await;
+                        assert_get(&client, key.clone(), Some(value.clone())).await;
                         tokio::time::sleep(Duration::from_millis(rng.gen_range(0..10))).await;
-                        assert_delete(&mut client, key.clone()).await;
+                        assert_delete(&client, key.clone()).await;
                         tokio::time::sleep(Duration::from_millis(rng.gen_range(0..10))).await;
-                        assert_get(&mut client, key.clone(), None).await;
+                        assert_get(&client, key.clone(), None).await;
                         tokio::time::sleep(Duration::from_millis(rng.gen_range(0..10))).await;
-                        assert_put(&mut client, key.clone(), value.clone()).await;
+                        assert_put(&client, key.clone(), value.clone()).await;
                         tokio::time::sleep(Duration::from_millis(rng.gen_range(0..10))).await;
-                        assert_get(&mut client, key.clone(), Some(value.clone())).await;
+                        assert_get(&client, key.clone(), Some(value.clone())).await;
                     }
                 }
             })

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -5,6 +5,18 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+anyhow = "1.0"
+async-trait = "0.1"
+itertools = "0.10.3"
+parking_lot = "0.12"
 runkv-common = { path = "../common" }
 runkv-proto = { path = "../proto" }
+thiserror = "1.0"
+tokio = { version = "1", features = [
+    "rt-multi-thread",
+    "sync",
+    "macros",
+    "time",
+] }
 tonic = "0.6.2"
+tracing = "0.1"

--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -5,10 +5,13 @@ use runkv_common::channel_pool::ChannelPool;
 use runkv_common::config::Node;
 use runkv_common::Worker;
 use runkv_proto::kv::kv_service_client::KvServiceClient;
-use tonic::transport::Channel;
+use runkv_proto::kv::*;
+use runkv_proto::rudder::control_service_client::ControlServiceClient;
+use runkv_proto::rudder::RouterRequest;
+use tonic::Request;
 use tracing::error;
 
-use crate::error::Result;
+use crate::error::{Error, KvError, Result};
 use crate::router::Router;
 use crate::worker::heartbeater::{Heartbeater, HeartbeaterOptions};
 
@@ -16,20 +19,21 @@ pub struct RunkvClientOptions {
     pub rudder: u64,
     pub rudder_host: String,
     pub rudder_port: u16,
+    /// Duration to auto sync router map. Disable auto sync if duration is zero.
     pub heartbeat_interval: Duration,
 }
 
 struct RunkvClientCore {
-    rudder: u64,
-    rudder_host: String,
-    rudder_port: u16,
-
     channel_pool: ChannelPool,
     router: Router,
 }
 
 #[derive(Clone)]
 pub struct RunkvClient {
+    rudder: u64,
+    _rudder_host: String,
+    _rudder_port: u16,
+
     core: Arc<RunkvClientCore>,
 }
 
@@ -46,27 +50,180 @@ impl RunkvClient {
             })
             .await;
 
-        let mut heartbeater = Heartbeater::new(HeartbeaterOptions {
-            rudder: options.rudder,
-            heartbeat_interval: options.heartbeat_interval,
-            router: router.clone(),
-            channel_pool: channel_pool.clone(),
-        });
-        // TODO: Keep the handle for gracefully shutdown.
-        let _handle = tokio::spawn(async move {
-            if let Err(e) = heartbeater.run().await {
-                error!("error raised when running runkv client heartbeater: {}", e);
-            }
-        });
+        if !options.heartbeat_interval.is_zero() {
+            let mut heartbeater = Heartbeater::new(HeartbeaterOptions {
+                rudder: options.rudder,
+                heartbeat_interval: options.heartbeat_interval,
+                router: router.clone(),
+                channel_pool: channel_pool.clone(),
+            });
+            // TODO: Keep the handle for gracefully shutdown.
+            let _handle = tokio::spawn(async move {
+                if let Err(e) = heartbeater.run().await {
+                    error!("error raised when running runkv client heartbeater: {}", e);
+                }
+            });
+        }
 
         Self {
+            rudder: options.rudder,
+            _rudder_host: options.rudder_host,
+            _rudder_port: options.rudder_port,
+
             core: Arc::new(RunkvClientCore {
-                rudder: options.rudder,
-                rudder_host: options.rudder_host,
-                rudder_port: options.rudder_port,
                 channel_pool,
                 router,
             }),
         }
+    }
+
+    pub async fn update_router(&self) -> Result<()> {
+        let channel = self
+            .core
+            .channel_pool
+            .get(self.rudder)
+            .await
+            .map_err(Error::err)?;
+        let mut client = ControlServiceClient::new(channel);
+        let rsp = client
+            .router(Request::new(RouterRequest::default()))
+            .await?
+            .into_inner();
+        self.core.router.update_key_ranges(rsp.key_ranges);
+        for (node, endpoint) in rsp.wheels {
+            self.core
+                .channel_pool
+                .put_node(Node {
+                    id: node,
+                    host: endpoint.host,
+                    port: endpoint.port as u16,
+                })
+                .await;
+        }
+        Ok(())
+    }
+
+    pub async fn get(&self, key: Vec<u8>) -> Result<Option<Vec<u8>>> {
+        let leader = match self.core.router.leader(&key) {
+            Some(leader) => leader,
+            None => return Err(KvError::TemporarilyNoLeader(key).into()),
+        };
+        let channel = self
+            .core
+            .channel_pool
+            .get(leader.node)
+            .await
+            .map_err(Error::err)?;
+        let mut client = KvServiceClient::new(channel);
+        let mut rsp = client
+            .kv(Request::new(KvRequest {
+                ops: vec![Op {
+                    r#type: OpType::Get.into(),
+                    key,
+                    ..Default::default()
+                }],
+                target: leader.raft_node,
+            }))
+            .await?
+            .into_inner();
+        if rsp.err() == ErrCode::Redirect {
+            return Err(KvError::Redirect.into());
+        }
+        let raw = rsp.ops.remove(0).value;
+        let value = if raw.is_empty() { None } else { Some(raw) };
+        Ok(value)
+    }
+
+    /// Snapshot get.
+    pub async fn sget(&self, key: Vec<u8>, sequence: u64) -> Result<Option<Vec<u8>>> {
+        let leader = match self.core.router.leader(&key) {
+            Some(leader) => leader,
+            None => return Err(KvError::TemporarilyNoLeader(key).into()),
+        };
+        let channel = self
+            .core
+            .channel_pool
+            .get(leader.node)
+            .await
+            .map_err(Error::err)?;
+        let mut client = KvServiceClient::new(channel);
+        let mut rsp = client
+            .kv(Request::new(KvRequest {
+                ops: vec![Op {
+                    r#type: OpType::Get.into(),
+                    key,
+                    sequence,
+                    ..Default::default()
+                }],
+                target: leader.raft_node,
+            }))
+            .await?
+            .into_inner();
+        if rsp.err() == ErrCode::Redirect {
+            return Err(KvError::Redirect.into());
+        }
+        let raw = rsp.ops.remove(0).value;
+        let value = if raw.is_empty() { None } else { Some(raw) };
+        Ok(value)
+    }
+
+    pub async fn put(&self, key: Vec<u8>, value: Vec<u8>) -> Result<()> {
+        assert!(!value.is_empty());
+        let leader = match self.core.router.leader(&key) {
+            Some(leader) => leader,
+            None => return Err(KvError::TemporarilyNoLeader(key).into()),
+        };
+        let channel = self
+            .core
+            .channel_pool
+            .get(leader.node)
+            .await
+            .map_err(Error::err)?;
+        let mut client = KvServiceClient::new(channel);
+        let rsp = client
+            .kv(Request::new(KvRequest {
+                ops: vec![Op {
+                    r#type: OpType::Put.into(),
+                    key,
+                    value,
+                    ..Default::default()
+                }],
+                target: leader.raft_node,
+            }))
+            .await?
+            .into_inner();
+        if rsp.err() == ErrCode::Redirect {
+            return Err(KvError::Redirect.into());
+        }
+        Ok(())
+    }
+
+    pub async fn delete(&self, key: Vec<u8>) -> Result<()> {
+        let leader = match self.core.router.leader(&key) {
+            Some(leader) => leader,
+            None => return Err(KvError::TemporarilyNoLeader(key).into()),
+        };
+        let channel = self
+            .core
+            .channel_pool
+            .get(leader.node)
+            .await
+            .map_err(Error::err)?;
+        let mut client = KvServiceClient::new(channel);
+        let rsp = client
+            .kv(Request::new(KvRequest {
+                ops: vec![Op {
+                    r#type: OpType::Delete.into(),
+                    key,
+                    ..Default::default()
+                }],
+                target: leader.raft_node,
+            }))
+            .await?
+            .into_inner();
+        if rsp.err() == ErrCode::Redirect {
+            return Err(KvError::Redirect.into());
+        }
+        Ok(())
     }
 }

--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -1,0 +1,72 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use runkv_common::channel_pool::ChannelPool;
+use runkv_common::config::Node;
+use runkv_common::Worker;
+use runkv_proto::kv::kv_service_client::KvServiceClient;
+use tonic::transport::Channel;
+use tracing::error;
+
+use crate::error::Result;
+use crate::router::Router;
+use crate::worker::heartbeater::{Heartbeater, HeartbeaterOptions};
+
+pub struct RunkvClientOptions {
+    pub rudder: u64,
+    pub rudder_host: String,
+    pub rudder_port: u16,
+    pub heartbeat_interval: Duration,
+}
+
+struct RunkvClientCore {
+    rudder: u64,
+    rudder_host: String,
+    rudder_port: u16,
+
+    channel_pool: ChannelPool,
+    router: Router,
+}
+
+#[derive(Clone)]
+pub struct RunkvClient {
+    core: Arc<RunkvClientCore>,
+}
+
+impl RunkvClient {
+    pub async fn open(options: RunkvClientOptions) -> Self {
+        let router = Router::default();
+        let channel_pool = ChannelPool::default();
+
+        channel_pool
+            .put_node(Node {
+                id: options.rudder,
+                host: options.rudder_host.clone(),
+                port: options.rudder_port,
+            })
+            .await;
+
+        let mut heartbeater = Heartbeater::new(HeartbeaterOptions {
+            rudder: options.rudder,
+            heartbeat_interval: options.heartbeat_interval,
+            router: router.clone(),
+            channel_pool: channel_pool.clone(),
+        });
+        // TODO: Keep the handle for gracefully shutdown.
+        let _handle = tokio::spawn(async move {
+            if let Err(e) = heartbeater.run().await {
+                error!("error raised when running runkv client heartbeater: {}", e);
+            }
+        });
+
+        Self {
+            core: Arc::new(RunkvClientCore {
+                rudder: options.rudder,
+                rudder_host: options.rudder_host,
+                rudder_port: options.rudder_port,
+                channel_pool,
+                router,
+            }),
+        }
+    }
+}

--- a/client/src/error.rs
+++ b/client/src/error.rs
@@ -1,0 +1,23 @@
+use tonic::Status;
+
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    #[error("rpc status error: {0}")]
+    RpcStatus(#[from] Status),
+    #[error("config error: {0}")]
+    ConfigError(String),
+    #[error("other: {0}")]
+    Other(String),
+}
+
+impl Error {
+    pub fn err(e: impl Into<Box<dyn std::error::Error>>) -> Error {
+        Error::Other(e.into().to_string())
+    }
+
+    pub fn config_err(e: impl Into<Box<dyn std::error::Error>>) -> Error {
+        Error::ConfigError(e.into().to_string())
+    }
+}
+
+pub type Result<T> = std::result::Result<T, Error>;

--- a/client/src/error.rs
+++ b/client/src/error.rs
@@ -4,6 +4,8 @@ use tonic::Status;
 pub enum Error {
     #[error("rpc status error: {0}")]
     RpcStatus(#[from] Status),
+    #[error("kv error: {0}")]
+    KvError(#[from] KvError),
     #[error("config error: {0}")]
     ConfigError(String),
     #[error("other: {0}")]
@@ -18,6 +20,18 @@ impl Error {
     pub fn config_err(e: impl Into<Box<dyn std::error::Error>>) -> Error {
         Error::ConfigError(e.into().to_string())
     }
+
+    pub fn redirect(&self) -> bool {
+        matches!(self, Self::KvError(KvError::Redirect))
+    }
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum KvError {
+    #[error("temporarily no leader for key: {0:?}")]
+    TemporarilyNoLeader(Vec<u8>),
+    #[error("valid leader changed, need redirect")]
+    Redirect,
 }
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -1,9 +1,4 @@
-#![allow(dead_code)]
-
-use runkv_proto::kv::kv_service_client::KvServiceClient;
-use tonic::transport::Channel;
-
-#[derive(Clone)]
-pub struct RunKVClient {
-    client: KvServiceClient<Channel>,
-}
+pub mod client;
+pub mod error;
+pub mod router;
+pub mod worker;

--- a/client/src/router.rs
+++ b/client/src/router.rs
@@ -1,0 +1,110 @@
+use std::collections::{BTreeMap, HashMap};
+use std::sync::Arc;
+
+use itertools::Itertools;
+use parking_lot::RwLock;
+use runkv_proto::meta::{KeyRange, KeyRangeInfo};
+
+fn _is_overlap(r1: &KeyRange, r2: &KeyRange) -> bool {
+    !(r1.start_key > r2.end_key || r1.end_key < r2.start_key)
+}
+
+fn in_range(key: &[u8], range: &KeyRange) -> bool {
+    key >= &range.start_key[..] && key < &range.end_key[..]
+}
+
+pub struct LeaderInfo {
+    pub node: u64,
+    pub group: u64,
+    pub raft_node: u64,
+}
+
+struct RouterCore {
+    /// { key range -> raft group id }
+    key_range_groups: BTreeMap<KeyRange, u64>,
+    /// { raft group id -> [raft node id] }
+    group_raft_nodes: HashMap<u64, Vec<u64>>,
+    /// { raft group id -> leader raft node id }
+    group_leader: HashMap<u64, u64>,
+    /// { raft node id -> node id }
+    raft_nodes: HashMap<u64, u64>,
+}
+
+#[derive(Clone)]
+pub struct Router {
+    core: Arc<RwLock<RouterCore>>,
+}
+
+impl Default for Router {
+    fn default() -> Self {
+        Self {
+            core: Arc::new(RwLock::new(RouterCore {
+                key_range_groups: BTreeMap::default(),
+                group_raft_nodes: HashMap::default(),
+                group_leader: HashMap::default(),
+                raft_nodes: HashMap::default(),
+            })),
+        }
+    }
+}
+
+impl Router {
+    pub fn leader(&self, key: &[u8]) -> Option<LeaderInfo> {
+        let core = self.core.read();
+        for (key_range, &group) in core.key_range_groups.iter() {
+            if in_range(key, key_range) {
+                if let Some(&leader) = core.group_leader.get(&group) {
+                    let node = core.raft_nodes.get(&leader).copied().unwrap();
+                    return Some(LeaderInfo {
+                        node,
+                        group,
+                        raft_node: leader,
+                    });
+                }
+                return None;
+            }
+        }
+        None
+    }
+
+    pub fn update_key_ranges(&self, key_range_infos: Vec<KeyRangeInfo>) {
+        let mut updated = RouterCore {
+            key_range_groups: BTreeMap::default(),
+            group_raft_nodes: HashMap::default(),
+            group_leader: HashMap::default(),
+            raft_nodes: HashMap::default(),
+        };
+        for KeyRangeInfo {
+            group,
+            key_range,
+            raft_nodes,
+            leader,
+        } in key_range_infos
+        {
+            let key_range = key_range.unwrap();
+
+            updated.key_range_groups.insert(key_range, group);
+            updated
+                .group_raft_nodes
+                .insert(group, raft_nodes.keys().copied().collect_vec());
+            updated.group_leader.insert(group, leader);
+            for (raft_node, node) in raft_nodes {
+                updated.raft_nodes.insert(raft_node, node);
+            }
+        }
+        let mut core = self.core.write();
+        *core = updated;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn is_send_sync_clone<T: Send + Sync + Clone + 'static>() {}
+
+    #[test]
+    fn ensure_send_sync_clone() {
+        is_send_sync_clone::<Router>();
+    }
+}

--- a/client/src/worker/heartbeater.rs
+++ b/client/src/worker/heartbeater.rs
@@ -1,0 +1,71 @@
+use std::time::Duration;
+
+use async_trait::async_trait;
+use runkv_common::channel_pool::ChannelPool;
+use runkv_common::Worker;
+use runkv_proto::rudder::control_service_client::ControlServiceClient;
+use runkv_proto::rudder::ListKeyRangesRequest;
+use tonic::Request;
+use tracing::warn;
+
+use crate::error::{Error, Result};
+use crate::router::Router;
+
+pub struct HeartbeaterOptions {
+    pub rudder: u64,
+    pub heartbeat_interval: Duration,
+
+    pub router: Router,
+    pub channel_pool: ChannelPool,
+}
+
+pub struct Heartbeater {
+    rudder: u64,
+    heartbeat_interval: Duration,
+
+    router: Router,
+    channel_pool: ChannelPool,
+}
+
+impl Heartbeater {
+    pub fn new(options: HeartbeaterOptions) -> Self {
+        Self {
+            rudder: options.rudder,
+            heartbeat_interval: options.heartbeat_interval,
+
+            router: options.router,
+            channel_pool: options.channel_pool,
+        }
+    }
+
+    async fn run_inner(&mut self) -> Result<()> {
+        loop {
+            tokio::time::sleep(self.heartbeat_interval).await;
+            let channel = self
+                .channel_pool
+                .get(self.rudder)
+                .await
+                .map_err(Error::err)?;
+            let mut client = ControlServiceClient::new(channel);
+            let infos = client
+                .list_key_ranges(Request::new(ListKeyRangesRequest::default()))
+                .await?
+                .into_inner()
+                .key_ranges;
+            self.router.update_key_ranges(infos);
+        }
+    }
+}
+
+#[async_trait]
+impl Worker for Heartbeater {
+    async fn run(&mut self) -> anyhow::Result<()> {
+        // TODO: Gracefully kill.
+        loop {
+            match self.run_inner().await {
+                Ok(_) => {}
+                Err(e) => warn!("error occur when heartbeater running: {}", e),
+            }
+        }
+    }
+}

--- a/client/src/worker/mod.rs
+++ b/client/src/worker/mod.rs
@@ -1,0 +1,1 @@
+pub mod heartbeater;

--- a/proto/src/proto/kv.proto
+++ b/proto/src/proto/kv.proto
@@ -2,6 +2,11 @@ syntax = "proto3";
 
 package kv;
 
+enum ErrCode {
+  OK = 0;
+  REDIRECT = 1;
+}
+
 message GetRequest {
   bytes key = 1;
   uint64 sequence = 2;
@@ -9,6 +14,7 @@ message GetRequest {
 
 message GetResponse {
   bytes value = 1;
+  ErrCode err = 100;
 }
 
 message PutRequest {
@@ -16,13 +22,17 @@ message PutRequest {
   bytes value = 2;
 }
 
-message PutResponse {}
+message PutResponse {
+  ErrCode err = 100;
+}
 
 message DeleteRequest {
   bytes key = 1;
 }
 
-message DeleteResponse {}
+message DeleteResponse {
+  ErrCode err = 100;
+}
 
 message SnapshotRequest {
   // A dummy key, infers that take snapshot of the shard that belongs.
@@ -31,6 +41,7 @@ message SnapshotRequest {
 
 message SnapshotResponse {
   uint64 sequence = 1;
+  ErrCode err = 100;
 }
 
 message KvOpRequest {
@@ -57,6 +68,7 @@ message TxnRequest {
 
 message TxnResponse {
   repeated KvOpResponse ops = 1;
+  ErrCode err = 100;
 }
 
 service KvService {

--- a/proto/src/proto/kv.proto
+++ b/proto/src/proto/kv.proto
@@ -7,74 +7,41 @@ enum ErrCode {
   REDIRECT = 1;
 }
 
-message GetRequest {
-  bytes key = 1;
-  uint64 sequence = 2;
+enum OpType {
+  NONE = 0;
+  GET = 1; // (key[, sequence]) -> (value)
+  PUT = 2; // (key, value) -> ()
+  DELETE = 3; // (key) -> ()
+  SNAPSHOT = 4; // () -> (sequence)
 }
 
-message GetResponse {
-  bytes value = 1;
-  ErrCode err = 100;
+enum Type {
+  T_NONE = 0;
+  T_GET = 1;
+  T_PUT = 2;
+  T_DELETE = 3;
+  T_SNAPSHOT = 4;
+  T_TXN = 5;
 }
 
-message PutRequest {
-  bytes key = 1;
-  bytes value = 2;
+message Op {
+  OpType type = 1;
+  bytes key = 2;
+  bytes value = 3;
+  uint64 sequence = 4;
 }
 
-message PutResponse {
-  ErrCode err = 100;
+message KvRequest {
+  repeated Op ops = 1;
+  // target raft node id
+  uint64 target = 2;
 }
 
-message DeleteRequest {
-  bytes key = 1;
-}
-
-message DeleteResponse {
-  ErrCode err = 100;
-}
-
-message SnapshotRequest {
-  // A dummy key, infers that take snapshot of the shard that belongs.
-  bytes key = 1;
-}
-
-message SnapshotResponse {
-  uint64 sequence = 1;
-  ErrCode err = 100;
-}
-
-message KvOpRequest {
-  oneof request {
-    GetRequest get = 1;
-    PutRequest put = 2;
-    DeleteRequest delete = 3;
-    SnapshotRequest snapshot = 4;
-  }
-}
-
-message KvOpResponse {
-  oneof response {
-    GetResponse get = 1;
-    PutResponse put = 2;
-    DeleteResponse delete = 3;
-    SnapshotResponse snapshot = 4;
-  }
-}
-
-message TxnRequest {
-  repeated KvOpRequest ops = 1;
-}
-
-message TxnResponse {
-  repeated KvOpResponse ops = 1;
-  ErrCode err = 100;
+message KvResponse {
+  repeated Op ops = 1;
+  ErrCode err = 2;
 }
 
 service KvService {
-  rpc Get(GetRequest) returns (GetResponse);
-  rpc Put(PutRequest) returns (PutResponse);
-  rpc Delete(DeleteRequest) returns (DeleteResponse);
-  rpc Snapshot(SnapshotRequest) returns (SnapshotResponse);
-  rpc Txn(TxnRequest) returns (TxnResponse);
+  rpc Kv(KvRequest) returns (KvResponse);
 }

--- a/proto/src/proto/meta.proto
+++ b/proto/src/proto/meta.proto
@@ -17,6 +17,9 @@ message KeyRangeInfo {
   meta.KeyRange key_range = 2;
   // { raft node id -> node id }
   map<uint64, uint64> raft_nodes = 3;
+  // leader raft node id
+  // Used by query router info.
+  uint64 leader = 4;
 }
 
 message WheelMeta {

--- a/proto/src/proto/rudder.proto
+++ b/proto/src/proto/rudder.proto
@@ -6,10 +6,14 @@ import "common.proto";
 import "manifest.proto";
 import "meta.proto";
 
+message RaftState {
+  bool is_leader = 1;
+}
+
 message WheelHeartbeatRequest {
   uint64 watermark = 1;
   uint64 next_version_id = 2;
-  map<uint64, bool> raft_states = 3;
+  map<uint64, RaftState> raft_states = 3;
 }
 
 message WheelHeartbeatResponse {
@@ -77,7 +81,14 @@ message AddKeyRangesRequest {
 
 message AddKeyRangesResponse {}
 
+message ListKeyRangesRequest {}
+
+message ListKeyRangesResponse {
+  repeated meta.KeyRangeInfo key_ranges = 1;
+}
+
 service ControlService {
   rpc AddWheels(AddWheelsRequest) returns (AddWheelsResponse);
   rpc AddKeyRanges(AddKeyRangesRequest) returns (AddKeyRangesResponse);
+  rpc ListKeyRanges(ListKeyRangesRequest) returns (ListKeyRangesResponse);
 }

--- a/proto/src/proto/rudder.proto
+++ b/proto/src/proto/rudder.proto
@@ -81,14 +81,15 @@ message AddKeyRangesRequest {
 
 message AddKeyRangesResponse {}
 
-message ListKeyRangesRequest {}
+message RouterRequest {}
 
-message ListKeyRangesResponse {
+message RouterResponse {
   repeated meta.KeyRangeInfo key_ranges = 1;
+  map<uint64, common.Endpoint> wheels = 2;
 }
 
 service ControlService {
   rpc AddWheels(AddWheelsRequest) returns (AddWheelsResponse);
   rpc AddKeyRanges(AddKeyRangesRequest) returns (AddKeyRangesResponse);
-  rpc ListKeyRanges(ListKeyRangesRequest) returns (ListKeyRangesResponse);
+  rpc Router(RouterRequest) returns (RouterResponse);
 }

--- a/rudder/src/meta/mod.rs
+++ b/rudder/src/meta/mod.rs
@@ -5,6 +5,7 @@ use std::time::{Duration, SystemTime};
 use async_trait::async_trait;
 use runkv_proto::common::Endpoint;
 use runkv_proto::meta::{KeyRange, KeyRangeInfo};
+use runkv_proto::rudder::RaftState;
 
 use crate::error::Result;
 
@@ -22,6 +23,12 @@ pub trait MetaStore: Send + Sync + 'static {
 
     /// Add new key range.
     async fn add_key_ranges(&self, key_ranges: Vec<KeyRangeInfo>) -> Result<()>;
+
+    /// Get all key range infos.
+    async fn all_key_range_infos(&self) -> Result<Vec<KeyRangeInfo>>;
+
+    /// Update raft states.
+    async fn update_raft_states(&self, raft_states: HashMap<u64, RaftState>) -> Result<()>;
 
     /// Update exhauster meta.
     async fn update_exhauster(&self, node_id: u64, endpoint: Endpoint) -> Result<()>;

--- a/rudder/src/service.rs
+++ b/rudder/src/service.rs
@@ -276,16 +276,17 @@ impl ControlService for Rudder {
     }
 
     #[tracing::instrument(level = "trace")]
-    async fn list_key_ranges(
+    async fn router(
         &self,
-        _request: Request<ListKeyRangesRequest>,
-    ) -> core::result::Result<Response<ListKeyRangesResponse>, Status> {
-        let infos = self
+        _request: Request<RouterRequest>,
+    ) -> core::result::Result<Response<RouterResponse>, Status> {
+        let key_ranges = self
             .meta_store
             .all_key_range_infos()
             .await
             .map_err(internal)?;
-        let rsp = ListKeyRangesResponse { key_ranges: infos };
+        let wheels = self.meta_store.wheels().await.map_err(internal)?;
+        let rsp = RouterResponse { key_ranges, wheels };
         Ok(Response::new(rsp))
     }
 }

--- a/rudder/src/service.rs
+++ b/rudder/src/service.rs
@@ -80,6 +80,10 @@ impl Rudder {
             .version_manager
             .version_diffs_from(hb.next_version_id, DEFAULT_VERSION_DIFF_BATCH)
             .await?;
+        self.meta_store
+            .update_raft_states(hb.raft_states)
+            .await
+            .map_err(internal)?;
         let rsp = heartbeat_response::HeartbeatMessage::WheelHeartbeat(WheelHeartbeatResponse {
             version_diffs,
         });
@@ -268,6 +272,20 @@ impl ControlService for Rudder {
         }
 
         let rsp = AddKeyRangesResponse::default();
+        Ok(Response::new(rsp))
+    }
+
+    #[tracing::instrument(level = "trace")]
+    async fn list_key_ranges(
+        &self,
+        _request: Request<ListKeyRangesRequest>,
+    ) -> core::result::Result<Response<ListKeyRangesResponse>, Status> {
+        let infos = self
+            .meta_store
+            .all_key_range_infos()
+            .await
+            .map_err(internal)?;
+        let rsp = ListKeyRangesResponse { key_ranges: infos };
         Ok(Response::new(rsp))
     }
 }

--- a/wheel/src/components/command.rs
+++ b/wheel/src/components/command.rs
@@ -1,13 +1,13 @@
 use runkv_common::coding::BytesSerde;
-use runkv_proto::kv::TxnRequest;
+use runkv_proto::kv::KvRequest;
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug)]
 pub enum Command {
-    TxnRequest {
+    KvRequest {
         request_id: u64,
         sequence: u64,
-        request: TxnRequest,
+        request: KvRequest,
     },
     CompactRaftLog {
         index: u64,

--- a/wheel/src/components/fsm.rs
+++ b/wheel/src/components/fsm.rs
@@ -3,11 +3,7 @@ use std::ops::Range;
 use async_trait::async_trait;
 use bytes::Bytes;
 use runkv_common::notify_pool::NotifyPool;
-use runkv_proto::kv::{
-    kv_op_request, kv_op_response, DeleteRequest, DeleteResponse, ErrCode, GetRequest, GetResponse,
-    KvOpResponse, PutRequest, PutResponse, SnapshotRequest, SnapshotResponse, TxnRequest,
-    TxnResponse,
-};
+use runkv_proto::kv::*;
 use runkv_storage::raft_log_store::error::RaftLogStoreError;
 use tracing::error;
 
@@ -68,7 +64,7 @@ pub struct ObjectLsmTreeFsmOptions {
 
     pub raft_log_store: RaftGroupLogStore,
     pub lsm_tree: ObjectStoreLsmTree,
-    pub txn_notify_pool: NotifyPool<u64, Result<TxnResponse>>,
+    pub txn_notify_pool: NotifyPool<u64, Result<KvResponse>>,
 }
 
 #[derive(Clone)]
@@ -79,7 +75,7 @@ pub struct ObjectLsmTreeFsm {
 
     raft_log_store: RaftGroupLogStore,
     lsm_tree: ObjectStoreLsmTree,
-    txn_notify_pool: NotifyPool<u64, Result<TxnResponse>>,
+    txn_notify_pool: NotifyPool<u64, Result<KvResponse>>,
 }
 
 impl std::fmt::Debug for ObjectLsmTreeFsm {
@@ -139,7 +135,7 @@ impl ObjectLsmTreeFsm {
         let cmds: Vec<Command> = bincode::deserialize(&entry.data).map_err(Error::serde_err)?;
         for cmd in cmds {
             match cmd {
-                Command::TxnRequest {
+                Command::KvRequest {
                     request_id,
                     sequence,
                     request,
@@ -165,7 +161,7 @@ impl ObjectLsmTreeFsm {
                             .observe(duration.as_secs_f64());
                     }
 
-                    let response = self.txn(request, sequence, entry.index).await;
+                    let response = self.kv(request, sequence, entry.index).await;
                     if let Err(e) = self.txn_notify_pool.notify(request_id, response) {
                         error!(request_id = request_id, "notify txn result error: {}", e);
                     }
@@ -179,46 +175,56 @@ impl ObjectLsmTreeFsm {
     }
 
     #[tracing::instrument(level = "trace")]
-    async fn txn(
+    async fn kv(
         &self,
-        request: TxnRequest,
+        request: KvRequest,
         sequence: u64,
         raft_log_index: u64,
-    ) -> Result<TxnResponse> {
+    ) -> Result<KvResponse> {
         let mut ops = Vec::with_capacity(request.ops.len());
         for op in request.ops {
-            let op = match op.request.unwrap() {
-                kv_op_request::Request::Get(GetRequest { key, sequence: seq }) => {
-                    kv_op_response::Response::Get(GetResponse {
-                        value: self
-                            .get(key, if seq > 0 { seq } else { sequence })
-                            .await?
-                            .unwrap_or_default(),
-                        err: ErrCode::Ok.into(),
-                    })
+            let op = match op.r#type() {
+                OpType::None => Op {
+                    r#type: OpType::None.into(),
+                    ..Default::default()
+                },
+                OpType::Get => {
+                    let value = self
+                        .get(
+                            op.key,
+                            if op.sequence > 0 {
+                                op.sequence
+                            } else {
+                                sequence
+                            },
+                        )
+                        .await?
+                        .unwrap_or_default();
+                    Op {
+                        r#type: OpType::Get.into(),
+                        value,
+                        ..Default::default()
+                    }
                 }
-                kv_op_request::Request::Put(PutRequest { key, value }) => {
-                    self.put(key, value, raft_log_index, sequence).await?;
-                    kv_op_response::Response::Put(PutResponse {
-                        err: ErrCode::Ok.into(),
-                    })
+                OpType::Put => {
+                    self.put(op.key, op.value, raft_log_index, sequence).await?;
+                    Op {
+                        r#type: OpType::Put.into(),
+                        ..Default::default()
+                    }
                 }
-                kv_op_request::Request::Delete(DeleteRequest { key }) => {
-                    self.delete(key, raft_log_index, sequence).await?;
-                    kv_op_response::Response::Delete(DeleteResponse {
-                        err: ErrCode::Ok.into(),
-                    })
+                OpType::Delete => {
+                    self.delete(op.key, raft_log_index, sequence).await?;
+                    Op {
+                        r#type: OpType::Delete.into(),
+                        ..Default::default()
+                    }
                 }
-                kv_op_request::Request::Snapshot(SnapshotRequest { .. }) => {
-                    kv_op_response::Response::Snapshot(SnapshotResponse {
-                        sequence,
-                        err: ErrCode::Ok.into(),
-                    })
-                }
+                OpType::Snapshot => todo!(),
             };
-            ops.push(KvOpResponse { response: Some(op) });
+            ops.push(op);
         }
-        Ok(TxnResponse {
+        Ok(KvResponse {
             ops,
             err: ErrCode::Ok.into(),
         })

--- a/wheel/src/lib.rs
+++ b/wheel/src/lib.rs
@@ -24,7 +24,7 @@ use runkv_common::prometheus::DefaultPrometheusExporter;
 use runkv_common::BoxedWorker;
 use runkv_proto::common::Endpoint as PbEndpoint;
 use runkv_proto::kv::kv_service_server::KvServiceServer;
-use runkv_proto::kv::TxnResponse;
+use runkv_proto::kv::KvResponse;
 use runkv_proto::wheel::raft_service_server::RaftServiceServer;
 use runkv_proto::wheel::wheel_service_server::WheelServiceServer;
 use runkv_storage::components::{
@@ -261,7 +261,7 @@ fn build_raft_manager(
     raft_log_store: RaftLogStore,
     raft_network: GrpcRaftNetwork,
     raft_states: RaftStates,
-    txn_notify_pool: NotifyPool<u64, Result<TxnResponse>>,
+    txn_notify_pool: NotifyPool<u64, Result<KvResponse>>,
     version_manager: VersionManager,
     sstable_store: SstableStoreRef,
     channel_pool: ChannelPool,
@@ -315,6 +315,6 @@ fn build_raft_manager(
     Ok(RaftManager::new(raft_manager_options))
 }
 
-fn build_txn_notify_pool() -> NotifyPool<u64, Result<TxnResponse>> {
+fn build_txn_notify_pool() -> NotifyPool<u64, Result<KvResponse>> {
     NotifyPool::new(65535)
 }

--- a/wheel/src/service.rs
+++ b/wheel/src/service.rs
@@ -334,6 +334,7 @@ impl WheelService for Wheel {
             group,
             key_range,
             raft_nodes,
+            ..
         } in req.key_ranges
         {
             let key_range = key_range.unwrap();

--- a/wheel/src/worker/heartbeater.rs
+++ b/wheel/src/worker/heartbeater.rs
@@ -9,7 +9,7 @@ use runkv_common::Worker;
 use runkv_proto::common::Endpoint;
 use runkv_proto::rudder::rudder_service_client::RudderServiceClient;
 use runkv_proto::rudder::{
-    heartbeat_request, heartbeat_response, HeartbeatRequest, WheelHeartbeatRequest,
+    heartbeat_request, heartbeat_response, HeartbeatRequest, RaftState, WheelHeartbeatRequest,
 };
 use runkv_storage::manifest::{ManifestError, VersionManager};
 use tonic::Request;
@@ -84,9 +84,11 @@ impl Heartbeater {
             .map(|(raft_node, ss)| {
                 (
                     raft_node,
-                    match ss {
-                        Some(ss) => ss.raft_state == raft::StateRole::Leader,
-                        None => false,
+                    RaftState {
+                        is_leader: match ss {
+                            Some(ss) => ss.raft_state == raft::StateRole::Leader,
+                            None => false,
+                        },
                     },
                 )
             })

--- a/wheel/src/worker/raft.rs
+++ b/wheel/src/worker/raft.rs
@@ -398,7 +398,7 @@ where
             for cmd in proposal.cmds.iter() {
                 let buf = bincode::serialize(cmd).unwrap();
                 let cmd: Command = bincode::deserialize(&buf).unwrap();
-                if let Command::TxnRequest { request_id, .. } = cmd {
+                if let Command::KvRequest { request_id, .. } = cmd {
                     let duration = {
                         let guard = TRACE_CTX.propose_ts.read(&request_id);
                         let ts = guard.get().unwrap();
@@ -503,7 +503,7 @@ where
                         {
                             let cmds: Vec<Command> = bincode::deserialize(&entry.data).unwrap();
                             for cmd in cmds {
-                                if let Command::TxnRequest { request_id, .. } = cmd {
+                                if let Command::KvRequest { request_id, .. } = cmd {
                                     let duration = {
                                         let guard = TRACE_CTX.propose_ts.read(&request_id);
                                         let ts = guard.get().unwrap();
@@ -607,7 +607,7 @@ where
                 {
                     let cmds: Vec<Command> = bincode::deserialize(&entry.data).unwrap();
                     for cmd in cmds {
-                        if let Command::TxnRequest { request_id, .. } = cmd {
+                        if let Command::KvRequest { request_id, .. } = cmd {
                             let duration = {
                                 let guard = TRACE_CTX.propose_ts.read(&request_id);
                                 let ts = guard.get().unwrap();


### PR DESCRIPTION
Introduce `RunkvClient`. Which fetch router from rudder and decide target wheel to send requests automatically.

Changes: 
- Introduce `RunkvClient`. Which fetch router from rudder and decide target wheel to send requests automatically.
- Wheel return `Redirect` error if `KvRequest` target is not in itself. *TODO: Return `Redirect` when target is not legal raft leader.*
- Refactor `kv.proto`.

TODOs:
- Return `Redirect` when target is not legal raft leader.
- Restore integration tests with runkv client.