### PR TITLE
feat: support multi wheel bench (on one node)

### DIFF
--- a/bench/bench_kv/main.rs
+++ b/bench/bench_kv/main.rs
@@ -43,13 +43,13 @@ const EXHAUSTER_NODE_ID_BASE: u64 = 100;
 
 const RUDDER_PORT: u16 = 12300;
 const WHEEL_PORT_BASE: u16 = 12300;
+const WHEEL_PROMETHEUS_PORT_BASE: u16 = 9890;
 const EXHAUSTER_PORT_BASE: u16 = 12400;
 
 const LOCALHOST: &str = "127.0.0.1";
 
 #[derive(Parser, Debug, Clone)]
 struct Args {
-    // TODO: Increase default value to 3.
     /// Count of wheel nodes, [1, 10].
     #[clap(long, default_value = "1")]
     wheels: u64,
@@ -277,6 +277,7 @@ async fn main() {
             config.raft_log_store.log_dir_path = format!("{}/{}", raft_log_store_data_dir, i);
             config.id = i + WHEEL_NODE_ID_BASE;
             config.port = i as u16 + WHEEL_PORT_BASE;
+            config.prometheus.port = i as u16 + WHEEL_PROMETHEUS_PORT_BASE;
             config
         };
         let (wheel, wheel_workers) =

--- a/bench/etc/wheel.toml
+++ b/bench/etc/wheel.toml
@@ -33,4 +33,4 @@ persist = "{persist}"
 
 [prometheus]
 host = "127.0.0.1"
-port = 9898
+port = 0

--- a/etc/prometheus.yml
+++ b/etc/prometheus.yml
@@ -1,8 +1,20 @@
 global:
-  scrape_interval: 15s 
-  evaluation_interval: 15s 
+  scrape_interval: 15s
+  evaluation_interval: 15s
 scrape_configs:
   - job_name: "prometheus-runkv"
     scrape_interval: 1s
     static_configs:
-      - targets: ["127.0.0.1:9898"]
+      - targets:
+          [
+            "127.0.0.1:9890",
+            "127.0.0.1:9891",
+            "127.0.0.1:9892",
+            "127.0.0.1:9893",
+            "127.0.0.1:9894",
+            "127.0.0.1:9895",
+            "127.0.0.1:9896",
+            "127.0.0.1:9897",
+            "127.0.0.1:9898",
+            "127.0.0.1:9899",
+          ]

--- a/storage/src/raft_log_store/metrics.rs
+++ b/storage/src/raft_log_store/metrics.rs
@@ -8,7 +8,7 @@ lazy_static! {
             "raft_log_store_latency_histogram_vec",
             "raft log store latency histogram vec",
             &["op", "node"],
-            vec![0.0001, 0.001, 0.005, 0.01, 0.02, 0.05]
+            vec![0.0001, 0.001, 0.005, 0.01, 0.02, 0.05, 0.1, 0.2, 0.5]
         )
         .unwrap();
     static ref RAFT_LOG_STORE_BLOCK_CACHE_LATENCY_HISTOGRAM_VEC: prometheus::HistogramVec =

--- a/wheel/src/components/raft_manager.rs
+++ b/wheel/src/components/raft_manager.rs
@@ -24,7 +24,7 @@ use super::lsm_tree::{ObjectStoreLsmTree, ObjectStoreLsmTreeOptions};
 use super::raft_log_store::RaftGroupLogStore;
 use super::raft_network::{GrpcRaftNetwork, RaftNetwork};
 use crate::error::{Error, RaftManageError, Result};
-use crate::worker::heartbeater::RaftStates;
+use crate::meta::MetaStoreRef;
 use crate::worker::raft::{RaftStartMode, RaftWorker, RaftWorkerOptions};
 use crate::worker::sstable_uploader::{SstableUploader, SstableUploaderOptions};
 
@@ -47,9 +47,9 @@ pub struct RaftManagerOptions {
     pub rudder_node_id: u64,
     pub raft_log_store: RaftLogStore,
     pub raft_network: GrpcRaftNetwork,
-    pub raft_states: RaftStates,
     pub txn_notify_pool: NotifyPool<u64, Result<KvResponse>>,
     pub version_manager: VersionManager,
+    pub meta_store: MetaStoreRef,
     pub sstable_store: SstableStoreRef,
     pub channel_pool: ChannelPool,
     pub lsm_tree_options: LsmTreeOptions,
@@ -69,11 +69,11 @@ pub struct RaftManager {
 
     raft_log_store: RaftLogStore,
     raft_network: GrpcRaftNetwork,
-    raft_states: RaftStates,
     raft_logger_root: slog::Logger,
 
     txn_notify_pool: NotifyPool<u64, Result<KvResponse>>,
     version_manager: VersionManager,
+    meta_store: MetaStoreRef,
     sstable_store: SstableStoreRef,
     channel_pool: ChannelPool,
 
@@ -91,10 +91,10 @@ impl RaftManager {
             rudder_node_id: options.rudder_node_id,
             raft_log_store: options.raft_log_store,
             raft_network: options.raft_network,
-            raft_states: options.raft_states,
             raft_logger_root,
             txn_notify_pool: options.txn_notify_pool,
             version_manager: options.version_manager,
+            meta_store: options.meta_store,
             sstable_store: options.sstable_store,
             lsm_tree_options: options.lsm_tree_options,
             channel_pool: options.channel_pool,
@@ -156,7 +156,7 @@ impl RaftManager {
             raft_log_store,
             raft_logger,
             raft_network: self.raft_network.clone(),
-            raft_states: self.raft_states.clone(),
+            meta_store: self.meta_store.clone(),
 
             command_packer: command_packer.clone(),
             message_packer,

--- a/wheel/src/meta/mod.rs
+++ b/wheel/src/meta/mod.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -23,6 +24,16 @@ pub trait MetaStore: Send + Sync + 'static {
     async fn in_range(&self, key: &[u8]) -> Result<Option<(KeyRange, u64, Vec<u64>)>>;
 
     async fn all_in_range(&self, keys: &[&[u8]]) -> Result<Option<(KeyRange, u64, Vec<u64>)>>;
+
+    async fn update_raft_state(
+        &self,
+        raft_node: u64,
+        raft_state: Option<raft::SoftState>,
+    ) -> Result<()>;
+
+    async fn all_raft_states(&self) -> Result<HashMap<u64, Option<raft::SoftState>>>;
+
+    async fn is_raft_leader(&self, raft_node: u64) -> Result<bool>;
 }
 
 pub type MetaStoreRef = Arc<dyn MetaStore>;

--- a/wheel/src/service.rs
+++ b/wheel/src/service.rs
@@ -152,6 +152,13 @@ impl Wheel {
             }
         };
 
+        if !self.inner.meta_store.is_raft_leader(target).await? {
+            return Ok(KvResponse {
+                ops: request.ops,
+                err: ErrCode::Redirect.into(),
+            });
+        }
+
         let sequence = self.inner.raft_manager.get_sequence(target).await?;
 
         // Critical area for propose sequence.


### PR DESCRIPTION
Now `bench_kv --wheels` can input `[1, 10]`.

**NOTE: Each wheel uses its own raft log store. Each raft log store sync itself. So performance will drop sharply if the latency of `fsync` of the disk for raft log store is high.**