### PR TITLE
feat: add tokio-console and parking_log deadlock detection support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@
 /.bin
 
 .DS_Store
+
+perf.data*
+flamegrapg.svg

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
 
 [[package]]
+name = "addr2line"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9ecd88a8c8378ca913a680cd98f0f13ac67383d35993f86c90a70e3f137816b"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -447,6 +462,64 @@ dependencies = [
 ]
 
 [[package]]
+name = "axum"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4af7447fc1214c1f3a1ace861d0216a6c8bb13965b64bbad9650f375b67689a"
+dependencies = [
+ "async-trait",
+ "axum-core",
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "itoa 1.0.1",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-http",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bdc19781b16e32f8a7200368a336fa4509d4b72ef15dd4e41df5290855ee1e6"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "mime",
+]
+
+[[package]]
+name = "backtrace"
+version = "0.3.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11a17d453482a265fd5f8479f2a3f405566e6ca627837aaddb85af8b1ab8ef61"
+dependencies = [
+ "addr2line",
+ "cc",
+ "cfg-if 1.0.0",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+]
+
+[[package]]
 name = "base64"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -654,6 +727,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30ed07550be01594c6026cff2a1d7fe9c8f683caa798e12b68694ac9e88286a3"
 dependencies = [
  "cache-padded",
+]
+
+[[package]]
+name = "console-api"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24cb05777feccbb2642d4f2df44d0505601a2cd88ca517d8c913f263a5a8dc8b"
+dependencies = [
+ "prost 0.10.3",
+ "prost-types 0.10.1",
+ "tonic 0.7.2",
+ "tracing-core",
+]
+
+[[package]]
+name = "console-subscriber"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f21a16ee925aa9d2bad2e296beffd6c5b1bfaad50af509d305b8e7f23af20fb"
+dependencies = [
+ "console-api",
+ "crossbeam-channel",
+ "crossbeam-utils 0.8.7",
+ "futures",
+ "hdrhistogram",
+ "humantime",
+ "prost-types 0.10.1",
+ "serde",
+ "serde_json",
+ "thread_local",
+ "tokio",
+ "tokio-stream",
+ "tonic 0.7.2",
+ "tracing",
+ "tracing-core",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -933,9 +1042,27 @@ dependencies = [
 
 [[package]]
 name = "fixedbitset"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d"
+
+[[package]]
+name = "fixedbitset"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "279fb028e20b3c4c320317955b77c5e0c9701f05a1d309905d6fc702cdc5053e"
+
+[[package]]
+name = "flate2"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39522e96686d38f4bc984b9198e3a0613264abaebaff2c5c918bfa6b6da09af"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crc32fast",
+ "libc",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "fnv"
@@ -1118,6 +1245,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "gimli"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78cc372d058dcf6d5ecd98510e7fbc9e5aec4d21de70f65fea8fecebcd881bd4"
+
+[[package]]
 name = "glob"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1153,6 +1286,19 @@ name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+
+[[package]]
+name = "hdrhistogram"
+version = "7.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31672b7011be2c4f7456c4ddbcb40e7e9a4a9fad8efe49a6ebaf5f307d0109c0"
+dependencies = [
+ "base64",
+ "byteorder",
+ "flate2",
+ "nom",
+ "num-traits",
+]
 
 [[package]]
 name = "heck"
@@ -1205,6 +1351,12 @@ dependencies = [
  "http",
  "pin-project-lite",
 ]
+
+[[package]]
+name = "http-range-header"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bfe8eed0a9285ef776bb792479ea3834e8b94e13d615c2f66d03dd50a435a29"
 
 [[package]]
 name = "httparse"
@@ -1477,6 +1629,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
 
 [[package]]
+name = "matchit"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73cbba799671b762df5a175adf59ce145165747bb891505c43d09aefbbf38beb"
+
+[[package]]
 name = "maybe-uninit"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1517,6 +1675,21 @@ name = "mime"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2b29bd4bc3f33391105ebee3589c19197c4271e3e5a9ec9bfe8127eeff8f082"
+dependencies = [
+ "adler",
+]
 
 [[package]]
 name = "mio"
@@ -1573,6 +1746,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 
 [[package]]
+name = "nom"
+version = "7.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8903e5a29a317527874d0402f867152a3d21c908bb0b933e416c65e301d4c36"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
 name = "ntapi"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1617,6 +1800,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c539a50b93a303167eded6e8dff5220cd39447409fb659f4cd24b1f72fe4f133"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "object"
+version = "0.28.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e42c982f2d955fac81dd7e1d0e1426a7d702acd9c98d19ab01083a6a0328c424"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -1800,10 +1992,13 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28141e0cc4143da2443301914478dc976a61ffdb3f043058310c70df2fed8954"
 dependencies = [
+ "backtrace",
  "cfg-if 1.0.0",
  "libc",
+ "petgraph 0.5.1",
  "redox_syscall",
  "smallvec",
+ "thread-id",
  "windows-sys",
 ]
 
@@ -1815,11 +2010,21 @@ checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
 name = "petgraph"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "467d164a6de56270bd7c4d070df81d07beace25012d5103ced4e9ff08d6afdb7"
+dependencies = [
+ "fixedbitset 0.2.0",
+ "indexmap",
+]
+
+[[package]]
+name = "petgraph"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a13a2fa9d0b63e5f22328828741e523766fff0ee9e779316902290dff3f824f"
 dependencies = [
- "fixedbitset",
+ "fixedbitset 0.4.1",
  "indexmap",
 ]
 
@@ -1963,7 +2168,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "444879275cb4fd84958b1a1d5420d15e6fcf7c235fe47f053c9c2a80aceb6001"
 dependencies = [
  "bytes",
- "prost-derive",
+ "prost-derive 0.9.0",
+]
+
+[[package]]
+name = "prost"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc03e116981ff7d8da8e5c220e374587b98d294af7ba7dd7fda761158f00086f"
+dependencies = [
+ "bytes",
+ "prost-derive 0.10.1",
 ]
 
 [[package]]
@@ -1978,9 +2193,9 @@ dependencies = [
  "lazy_static",
  "log",
  "multimap",
- "petgraph",
- "prost",
- "prost-types",
+ "petgraph 0.6.0",
+ "prost 0.9.0",
+ "prost-types 0.9.0",
  "regex",
  "tempfile",
  "which",
@@ -2000,13 +2215,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost-derive"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b670f45da57fb8542ebdbb6105a925fe571b67f9e7ed9f47a06a84e72b4e7cc"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "prost-types"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "534b7a0e836e3c482d2693070f982e39e7611da9695d4d1f5a4b186b51faef0a"
 dependencies = [
  "bytes",
- "prost",
+ "prost 0.9.0",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d0a014229361011dc8e69c8a1ec6c2e8d0f2af7c91e3ea3f5b2170298461e68"
+dependencies = [
+ "bytes",
+ "prost 0.10.3",
 ]
 
 [[package]]
@@ -2061,7 +2299,7 @@ dependencies = [
  "futures",
  "fxhash",
  "getset",
- "prost",
+ "prost 0.9.0",
  "protobuf",
  "raft-proto",
  "rand",
@@ -2081,12 +2319,12 @@ version = "0.7.0"
 source = "git+https://github.com/mrcroxx/raft-rs?rev=710b3a9cf2342cdcc1d7b43e945490945024ecd2#710b3a9cf2342cdcc1d7b43e945490945024ecd2"
 dependencies = [
  "lazy_static",
- "prost",
+ "prost 0.9.0",
  "prost-build",
  "protobuf",
  "serde",
  "serde_derive",
- "tonic",
+ "tonic 0.6.2",
  "tonic-build",
 ]
 
@@ -2250,7 +2488,7 @@ dependencies = [
  "tikv-jemallocator",
  "tokio",
  "toml",
- "tonic",
+ "tonic 0.6.2",
  "tracing",
 ]
 
@@ -2266,7 +2504,7 @@ dependencies = [
  "runkv-proto",
  "thiserror",
  "tokio",
- "tonic",
+ "tonic 0.6.2",
  "tracing",
 ]
 
@@ -2281,6 +2519,7 @@ dependencies = [
  "bytesize",
  "chrono",
  "clap 3.1.6",
+ "console-subscriber",
  "criterion",
  "env_logger",
  "futures",
@@ -2303,7 +2542,7 @@ dependencies = [
  "test-log",
  "tokio",
  "toml",
- "tonic",
+ "tonic 0.6.2",
  "tracing",
  "tracing-appender",
  "tracing-opentelemetry",
@@ -2324,7 +2563,7 @@ dependencies = [
  "humantime-serde",
  "itertools",
  "parking_lot 0.12.0",
- "prost",
+ "prost 0.9.0",
  "runkv-common",
  "runkv-proto",
  "runkv-storage",
@@ -2335,7 +2574,7 @@ dependencies = [
  "tikv-jemallocator",
  "tokio",
  "toml",
- "tonic",
+ "tonic 0.6.2",
  "tracing",
  "tracing-subscriber",
 ]
@@ -2346,12 +2585,12 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bytes",
- "prost",
+ "prost 0.9.0",
  "prost-build",
  "runkv-common",
  "serde",
  "serde_derive",
- "tonic",
+ "tonic 0.6.2",
  "tonic-build",
 ]
 
@@ -2371,7 +2610,7 @@ dependencies = [
  "humantime-serde",
  "itertools",
  "parking_lot 0.12.0",
- "prost",
+ "prost 0.9.0",
  "rand",
  "runkv-common",
  "runkv-proto",
@@ -2383,7 +2622,7 @@ dependencies = [
  "tikv-jemallocator",
  "tokio",
  "toml",
- "tonic",
+ "tonic 0.6.2",
  "tracing",
  "tracing-subscriber",
 ]
@@ -2443,6 +2682,7 @@ dependencies = [
  "futures",
  "itertools",
  "lazy_static",
+ "parking_lot 0.12.0",
  "rand",
  "runkv-client",
  "runkv-common",
@@ -2455,7 +2695,7 @@ dependencies = [
  "test-log",
  "tokio",
  "toml",
- "tonic",
+ "tonic 0.6.2",
  "tracing",
 ]
 
@@ -2483,7 +2723,7 @@ dependencies = [
  "moka",
  "parking_lot 0.12.0",
  "prometheus",
- "prost",
+ "prost 0.9.0",
  "raft",
  "rand",
  "runkv-common",
@@ -2498,10 +2738,16 @@ dependencies = [
  "tikv-jemallocator",
  "tokio",
  "toml",
- "tonic",
+ "tonic 0.6.2",
  "tracing",
  "tracing-subscriber",
 ]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
 
 [[package]]
 name = "rustc_version"
@@ -2821,6 +3067,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sync_wrapper"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20518fe4a4c9acf048008599e464deb21beeae3d3578418951a189c235a7a9a8"
+
+[[package]]
 name = "tagptr"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2910,6 +3162,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "thread-id"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fdfe0627923f7411a43ec9ec9c39c3a9b4151be313e0922042581fb6c9b717f"
+dependencies = [
+ "libc",
+ "redox_syscall",
+ "winapi",
 ]
 
 [[package]]
@@ -3031,6 +3294,7 @@ dependencies = [
  "pin-project-lite",
  "socket2",
  "tokio-macros",
+ "tracing",
  "winapi",
 ]
 
@@ -3133,11 +3397,43 @@ dependencies = [
  "hyper-timeout",
  "percent-encoding",
  "pin-project",
- "prost",
- "prost-derive",
+ "prost 0.9.0",
+ "prost-derive 0.9.0",
  "tokio",
  "tokio-stream",
  "tokio-util 0.6.9",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+ "tracing-futures",
+]
+
+[[package]]
+name = "tonic"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5be9d60db39854b30b835107500cf0aca0b0d14d6e1c3de124217c23a29c2ddb"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "axum",
+ "base64",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-timeout",
+ "percent-encoding",
+ "pin-project",
+ "prost 0.10.3",
+ "prost-derive 0.10.1",
+ "tokio",
+ "tokio-stream",
+ "tokio-util 0.7.0",
  "tower",
  "tower-layer",
  "tower-service",
@@ -3175,6 +3471,25 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d342c6d58709c0a6d48d48dabbb62d4ef955cf5f0f3bbfd845838e7ae88dbae"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-range-header",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]
@@ -3226,9 +3541,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.23"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa31669fa42c09c34d94d8165dd2012e8ff3c66aca50f3bb226b68f216f2706c"
+checksum = "f54c8ca710e81886d498c2fd3331b56c93aa248d49de2222ad2742247c60072f"
 dependencies = [
  "lazy_static",
  "valuable",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,4 +13,7 @@ members = [
 
 [profile.bench]
 # Uncomment this line if you are generating flame graph.
-# debug = true
+debug = true
+
+[profile.release]
+debug = true

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ check:
 	cargo check --tests
 
 test:
-	cargo nextest run
+	cargo nextest run --features deadlock
 
 proto:
 	cd proto/src/proto && prototool format -w && buf lint

--- a/bench/Cargo.toml
+++ b/bench/Cargo.toml
@@ -39,6 +39,8 @@ tikv-jemallocator = "0.4.3"
 
 [features]
 tracing = ["runkv-wheel/tracing"]
+deadlock = ["runkv-tests/deadlock"]
+console = ["tokio/tracing", "runkv-common/console"]
 
 [[bin]]
 name = "bench_kv"

--- a/bench/bench_kv/main.rs
+++ b/bench/bench_kv/main.rs
@@ -24,6 +24,9 @@ const EXHAUSTER_PORT_BASE: u16 = 12400;
 
 #[tokio::main]
 async fn main() {
+    let args = Args::parse();
+    println!("{:#?}", args);
+
     let options = Options {
         log: true,
         rudder_config_path: RUDDER_CONFIG_PATH.to_string(),
@@ -39,9 +42,6 @@ async fn main() {
         exhauster_port_base: EXHAUSTER_PORT_BASE,
     };
     println!("{:#?}", options);
-
-    let args = Args::parse();
-    println!("{:#?}", args);
 
     run(args, options).await;
 }

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -12,6 +12,7 @@ bytes = "1"
 bytesize = { version = "1.1.0", features = ["serde"] }
 chrono = "0.4"
 clap = { version = "3.1.6", features = ["derive"] }
+console-subscriber = { version = "0.1.5", optional = true }
 futures = "0.3"
 http = "0.2.6"
 humantime = "2.1.0"
@@ -46,6 +47,9 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 criterion = { version = "0.3", features = ["async", "async_tokio"] }
 env_logger = "*"
 test-log = "0.2.10"
+
+[features]
+console = ["console-subscriber"]
 
 [[bench]]
 name = "bench_sharded_hash_map"

--- a/common/src/log.rs
+++ b/common/src/log.rs
@@ -4,8 +4,9 @@ use tracing_subscriber::layer::{Layer, SubscriberExt};
 use tracing_subscriber::util::SubscriberInitExt;
 
 pub struct LogGuard {
-    _file_appender_guard: tracing_appender::non_blocking::WorkerGuard,
-    jaeger_enabled: bool,
+    _file_appender_guard: Option<tracing_appender::non_blocking::WorkerGuard>,
+    pub jaeger_enabled: bool,
+    pub tokio_console_enabled: bool,
 }
 
 impl Drop for LogGuard {
@@ -17,18 +18,17 @@ impl Drop for LogGuard {
 }
 
 pub fn init_runkv_logger(service: &str, id: u64, log_path: &str) -> LogGuard {
-    let jaeger_enabled = match std::env::var("RUNKV_TRACE") {
-        Err(_) => false,
-        Ok(val) => val.parse().unwrap(),
-    };
+    let tokio_console_enabled = cfg!(feature = "console");
+    let jaeger_enabled = cfg!(feature = "tracing");
 
     let (file_appender, file_appender_guard) = tracing_appender::non_blocking(
         tracing_appender::rolling::daily(log_path, format!("runkv-{}-{}.log", service, id)),
     );
 
     let guard = LogGuard {
-        _file_appender_guard: file_appender_guard,
+        _file_appender_guard: Some(file_appender_guard),
         jaeger_enabled,
+        tokio_console_enabled,
     };
 
     let fmt_layer = {
@@ -51,6 +51,17 @@ pub fn init_runkv_logger(service: &str, id: u64, log_path: &str) -> LogGuard {
             .with_filter(filter)
     };
 
+    if tokio_console_enabled {
+        #[cfg(feature = "console")]
+        {
+            console_subscriber::init();
+            return LogGuard {
+                _file_appender_guard: None,
+                jaeger_enabled,
+                tokio_console_enabled,
+            };
+        }
+    }
     if jaeger_enabled {
         opentelemetry::global::set_text_map_propagator(opentelemetry_jaeger::Propagator::new());
 

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -17,6 +17,7 @@ env_logger = "*"
 futures = "0.3"
 itertools = "0.10.3"
 lazy_static = "1.4.0"
+parking_lot = "0.12"
 rand = "0.8.5"
 runkv-client = { path = "../client" }
 runkv-common = { path = "../common" }
@@ -39,3 +40,4 @@ tracing = "0.1"
 
 [features]
 tracing = ["runkv-wheel/tracing"]
+deadlock = ["parking_lot/deadlock_detection"]


### PR DESCRIPTION
As titled.

Example (enable tokio-console and deadlock detection):
```bash
RUSTFLAGS="--cfg tokio_unstable" RUNKV_METRICS=true RUST_BACKTRACE=1 cargo run --features console,deadlock --release --package runkv-bench --bin bench_kv -- --loop 1000
```

Ref: #160 .