### PR TITLE
bench: compare block and stream compression

### DIFF
--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -62,6 +62,10 @@ harness = false
 # Uncomment this line if you are generating flame graph.
 # debug = true
 
+[[bench]]
+name = "bench_compression"
+harness = false
+
 [[bin]]
 name = "bench_raft_log_store"
 path = "bench/bench_raft_log_store.rs"

--- a/storage/benches/bench_compression.rs
+++ b/storage/benches/bench_compression.rs
@@ -1,0 +1,97 @@
+use std::io::Write;
+
+use bytes::BufMut;
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use rand::prelude::StdRng;
+use rand::{Rng, SeedableRng};
+
+const TABLES_PER_SSTABLE: u32 = 10;
+const KEYS_PER_TABLE: u64 = 100;
+
+fn gen_dataset(vsize: usize) -> Vec<Vec<u8>> {
+    let mut dataset = vec![];
+    let mut rng = StdRng::seed_from_u64(0);
+    for t in 1..=TABLES_PER_SSTABLE {
+        for i in 1..=KEYS_PER_TABLE {
+            let mut v = vec![0; vsize];
+            rng.fill(&mut v[..]);
+            let mut buf = vec![];
+            buf.put_u32(t);
+            buf.put_u64(i);
+            buf.put_slice(&v);
+            dataset.push(buf)
+        }
+    }
+    dataset
+}
+
+fn gen_data(dataset: &[Vec<u8>]) -> Vec<u8> {
+    let mut data = vec![];
+    for entry in dataset.iter() {
+        data.put_slice(entry);
+    }
+    data
+}
+
+fn block_compression(data: Vec<u8>) -> Vec<u8> {
+    let mut encoder = lz4::EncoderBuilder::new().level(4).build(vec![]).unwrap();
+    encoder.write_all(&data).unwrap();
+    let (buf, result) = encoder.finish();
+    result.unwrap();
+    buf
+}
+
+fn stream_compression(dataset: Vec<Vec<u8>>) -> Vec<u8> {
+    let buf = vec![];
+    let mut encoder = lz4::EncoderBuilder::new().level(4).build(buf).unwrap();
+    for entry in dataset {
+        encoder.write_all(&entry).unwrap();
+    }
+    let (buf, result) = encoder.finish();
+    result.unwrap();
+    buf
+}
+
+fn bench_compression(c: &mut Criterion) {
+    for vsize in [8, 16, 32, 64] {
+        let dataset = gen_dataset(vsize);
+        let data = gen_data(&dataset);
+
+        c.bench_with_input(
+            BenchmarkId::new(format!("buffer - vsize: {}B", vsize), ""),
+            &dataset,
+            |b, dataset| b.iter(|| gen_data(dataset)),
+        );
+
+        c.bench_with_input(
+            BenchmarkId::new(format!("block compression - vsize: {}B", vsize), ""),
+            &data,
+            |b, data| b.iter(|| block_compression(data.clone())),
+        );
+
+        c.bench_with_input(
+            BenchmarkId::new(format!("stream compression - vsize: {}B", vsize), ""),
+            &dataset,
+            |b, dataset| b.iter(|| stream_compression(dataset.clone())),
+        );
+
+        let uncompressed = data.len();
+        let block_compressed = block_compression(data).len();
+        let stream_compressed = stream_compression(dataset).len();
+
+        println!("uncompressed size: {}", uncompressed);
+        println!(
+            "block compressed size: {}, rate: {:.3}",
+            block_compressed,
+            block_compressed as f64 / uncompressed as f64
+        );
+        println!(
+            "stream compressed size: {}, rate: {:.3}",
+            stream_compressed,
+            stream_compressed as f64 / uncompressed as f64
+        );
+    }
+}
+
+criterion_group!(benches, bench_compression);
+criterion_main!(benches);


### PR DESCRIPTION
## What changes were proposed in this pull request?

Introduce benchmark for comparing block and stream compression. With stream compression, compressed block size can be better aligned.

Results:
```plain
buffer - vsize: 8B/     time:   [2.1603 us 2.1619 us 2.1634 us]
Found 4 outliers among 100 measurements (4.00%)
  1 (1.00%) high mild
  3 (3.00%) high severe

block compression - vsize: 8B/
                        time:   [124.39 us 124.45 us 124.51 us]
Found 3 outliers among 100 measurements (3.00%)
  2 (2.00%) high mild
  1 (1.00%) high severe

stream compression - vsize: 8B/
                        time:   [185.69 us 185.79 us 185.89 us]
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high mild

uncompressed size: 20000
block compressed size: 11887, rate: 0.594
stream compressed size: 11887, rate: 0.594
buffer - vsize: 16B/    time:   [2.8762 us 2.8778 us 2.8794 us]
Found 4 outliers among 100 measurements (4.00%)
  4 (4.00%) high mild

block compression - vsize: 16B/
                        time:   [209.27 us 209.49 us 209.82 us]
Found 3 outliers among 100 measurements (3.00%)
  1 (1.00%) high mild
  2 (2.00%) high severe

stream compression - vsize: 16B/
                        time:   [270.70 us 270.93 us 271.20 us]
Found 7 outliers among 100 measurements (7.00%)
  4 (4.00%) high mild
  3 (3.00%) high severe

uncompressed size: 28000
block compressed size: 20877, rate: 0.746
stream compressed size: 20877, rate: 0.746
buffer - vsize: 32B/    time:   [3.6046 us 3.6098 us 3.6161 us]
Found 5 outliers among 100 measurements (5.00%)
  1 (1.00%) high mild
  4 (4.00%) high severe

block compression - vsize: 32B/
                        time:   [427.75 us 427.92 us 428.09 us]
Found 6 outliers among 100 measurements (6.00%)
  3 (3.00%) high mild
  3 (3.00%) high severe

stream compression - vsize: 32B/
                        time:   [487.72 us 487.95 us 488.23 us]
Found 4 outliers among 100 measurements (4.00%)
  2 (2.00%) high mild
  2 (2.00%) high severe

uncompressed size: 44000
block compressed size: 36889, rate: 0.838
stream compressed size: 36889, rate: 0.838
buffer - vsize: 64B/    time:   [5.4895 us 5.4917 us 5.4941 us]
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild

block compression - vsize: 64B/
                        time:   [977.45 us 977.77 us 978.11 us]
Found 10 outliers among 100 measurements (10.00%)
  6 (6.00%) high mild
  4 (4.00%) high severe

Benchmarking stream compression - vsize: 64B/: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 5.3s, enable flat sampling, or reduce sample count to 60.
stream compression - vsize: 64B/
                        time:   [1.0419 ms 1.0425 ms 1.0432 ms]
Found 4 outliers among 100 measurements (4.00%)
  3 (3.00%) high mild
  1 (1.00%) high severe

uncompressed size: 76000
block compressed size: 68900, rate: 0.907
stream compressed size: 68900, rate: 0.907
```


## Which issues is this PR related to?

#171 